### PR TITLE
fix: color switcher style bugs

### DIFF
--- a/src/components/SwatchPaletteWidget/SwatchPaletteWidget.js
+++ b/src/components/SwatchPaletteWidget/SwatchPaletteWidget.js
@@ -44,7 +44,7 @@ class SwatchPaletteWidget extends Component {
 
     return (
       <div className={`${prefix}--swatch-palettes-container`}>
-        <div className="sticky-container" style={{ top: top || '0px' }}>
+        <div className="sticky-container" style={{ top }}>
           <div className={`${prefix}--row`}>
             <div
               className={`${prefix}--col-lg-4 ${prefix}--col-md-4 ${prefix}--col-no-gutter`}>

--- a/src/components/SwatchPaletteWidget/_swatch-palette-widget.scss
+++ b/src/components/SwatchPaletteWidget/_swatch-palette-widget.scss
@@ -49,10 +49,7 @@
     padding: 0 $spacing-05;
     background: $ui-01;
     top: 0;
-
-    @include carbon--breakpoint('md') {
-      padding-top: $spacing-09;
-    }
+    padding-top: $spacing-09;
   }
 }
 

--- a/src/components/SwatchPaletteWidget/_swatch-palette-widget.scss
+++ b/src/components/SwatchPaletteWidget/_swatch-palette-widget.scss
@@ -48,7 +48,7 @@
     margin: 0 -1rem;
     padding: 0 $spacing-05;
     background: $ui-01;
-    top: 0;
+    top: 3rem;
   }
 }
 

--- a/src/components/SwatchPaletteWidget/_swatch-palette-widget.scss
+++ b/src/components/SwatchPaletteWidget/_swatch-palette-widget.scss
@@ -90,4 +90,8 @@
 
 .#{$prefix}--swatch-palettes-container .#{$prefix}--content-switcher-btn {
   border-radius: 0;
+
+  &::before {
+    display: none;
+  }
 }

--- a/src/components/SwatchPaletteWidget/_swatch-palette-widget.scss
+++ b/src/components/SwatchPaletteWidget/_swatch-palette-widget.scss
@@ -61,7 +61,6 @@
   .#{$prefix}--content-switcher-btn {
     flex: 1;
     width: calc(25% - 1px);
-    margin-right: 1px;
     height: rem(48px);
     padding: $spacing-03 $spacing-05;
     outline: none;
@@ -86,4 +85,8 @@
 
 .#{$prefix}--swatch-palettes-container .#{$prefix}--content-switcher-btn {
   border-radius: 0;
+
+  &::before {
+    height: 100%;
+  }
 }

--- a/src/components/SwatchPaletteWidget/_swatch-palette-widget.scss
+++ b/src/components/SwatchPaletteWidget/_swatch-palette-widget.scss
@@ -49,7 +49,6 @@
     padding: 0 $spacing-05;
     background: $ui-01;
     top: 0;
-    padding-top: $spacing-09;
   }
 }
 

--- a/src/components/SwatchPaletteWidget/_swatch-palette-widget.scss
+++ b/src/components/SwatchPaletteWidget/_swatch-palette-widget.scss
@@ -86,8 +86,4 @@
 
 .#{$prefix}--swatch-palettes-container .#{$prefix}--content-switcher-btn {
   border-radius: 0;
-
-  &::before {
-    display: none;
-  }
 }

--- a/src/pages/elements/color.mdx
+++ b/src/pages/elements/color.mdx
@@ -107,7 +107,6 @@ Having multiple gray families gives each design the opportunity for nuance and m
 Each of the 10 color families have been divided into 10 swatches ranging from light to dark. RGB and HEX values are provided for digital appliations along with Pantone and CMYK values for print.
 
 <SwatchPaletteWidget
-  top="0"
   palettes={[
     ['red', 'magenta', 'purple', 'blue', 'cyan', 'teal', 'green'],
     ['cool gray-bw', 'gray-bw', 'warm gray-bw'],


### PR DESCRIPTION
Closes #101

This PR contains some style fixes for the color switcher component. One thing to note though is that the space between the copy and the color switcher is slightly larger than 16px due to the margin applied to every text paragraph

#### Changelog

**Changed**

- top padding of sticky color switcher for mobile breakpoints

**Removed**

- content switcher button borders
- color switcher sticky container top padding 
