### PR TITLE
feat: add link to bottom of left hand nav

### DIFF
--- a/src/gatsby-theme-carbon/components/LeftNav/ResourceLinks.js
+++ b/src/gatsby-theme-carbon/components/LeftNav/ResourceLinks.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import ResourceLinks from 'gatsby-theme-carbon/src/components/LeftNav/ResourceLinks';
+
+const links = [
+  {
+    title: 'Design Kit',
+    href: 'https://www.carbondesignsystem.com/resources#theme-libraries',
+  },
+];
+
+// shouldOpenNewTabs: true if outbound links should open in a new tab
+const CustomResources = () => <ResourceLinks shouldOpenNewTabs links={links} />;
+
+export default CustomResources;


### PR DESCRIPTION
Closes #92 

Adds a link to Design Kit to the bottom of the left-hand nav by shadowing ResourceLinks file

#### Changelog

**New**

- nav link
