### PR TITLE
fix: typeface page styles and include Carbon Slider

### DIFF
--- a/src/components/TypeFaceSubFamilies/_typeface-sub-families.scss
+++ b/src/components/TypeFaceSubFamilies/_typeface-sub-families.scss
@@ -64,26 +64,16 @@
 }
 
 .#{$prefix}--subfamilies-TypeTesterExample {
-  @include carbon--type-style('expressive-heading-05');
+  @include carbon--type-style('expressive-heading-05', true);
   background-color: $carbon--white-0;
   padding-top: $spacing-05;
   padding-bottom: 2.5rem;
   margin-bottom: 0;
   display: flex;
   flex-direction: column;
-  font-size: calc(2rem + 0.25 * (100vw - 20rem) / 22);
 
   @include carbon--breakpoint('md') {
     flex-direction: row;
-    font-size: calc(2.25rem + 0.375 * (100vw - 42rem) / 24);
-  }
-
-  @include carbon--breakpoint('lg') {
-    font-size: calc(2.625rem + 0.375 * (100vw - 66rem) / 16);
-  }
-
-  @include carbon--breakpoint('xlg') {
-    font-size: calc(3rem + 0.75 * (100vw - 82rem) / 17);
   }
 
   .ibm-type-italic {

--- a/src/components/TypeFaceSubFamilies/_typeface-sub-families.scss
+++ b/src/components/TypeFaceSubFamilies/_typeface-sub-families.scss
@@ -70,6 +70,19 @@
   padding-bottom: 2.5rem;
   margin-bottom: 0;
   display: flex;
+  font-size: calc(2rem + 0.25 * (100vw - 20rem) / 22);
+
+  @include carbon--breakpoint('md') {
+    font-size: calc(2.25rem + 0.375 * (100vw - 42rem) / 24);
+  }
+
+  @include carbon--breakpoint('lg') {
+    font-size: calc(2.625rem + 0.375 * (100vw - 66rem) / 16);
+  }
+
+  @include carbon--breakpoint('xlg') {
+    font-size: calc(3rem + 0.75 * (100vw - 82rem) / 17);
+  }
 
   .ibm-type-italic {
     font-style: italic;

--- a/src/components/TypeFaceSubFamilies/_typeface-sub-families.scss
+++ b/src/components/TypeFaceSubFamilies/_typeface-sub-families.scss
@@ -84,6 +84,10 @@
     font-size: calc(3rem + 0.75 * (100vw - 82rem) / 17);
   }
 
+  @include carbon--breakpoint('max') {
+    @include carbon--type-style('expressive-heading-05', true);
+  }
+
   .ibm-type-italic {
     font-style: italic;
   }

--- a/src/components/TypeFaceSubFamilies/_typeface-sub-families.scss
+++ b/src/components/TypeFaceSubFamilies/_typeface-sub-families.scss
@@ -70,9 +70,11 @@
   padding-bottom: 2.5rem;
   margin-bottom: 0;
   display: flex;
+  flex-direction: column;
   font-size: calc(2rem + 0.25 * (100vw - 20rem) / 22);
 
   @include carbon--breakpoint('md') {
+    flex-direction: row;
     font-size: calc(2.25rem + 0.375 * (100vw - 42rem) / 24);
   }
 

--- a/src/components/TypeFaceSubFamilies/_typeface-sub-families.scss
+++ b/src/components/TypeFaceSubFamilies/_typeface-sub-families.scss
@@ -46,7 +46,7 @@
   text-overflow: ellipsis;
 
   &:hover {
-    background-color: $carbon--gray-10;
+    background-color: $hover-ui;
   }
 
   &:last-child {
@@ -82,10 +82,6 @@
 
   @include carbon--breakpoint('xlg') {
     font-size: calc(3rem + 0.75 * (100vw - 82rem) / 17);
-  }
-
-  @include carbon--breakpoint('max') {
-    @include carbon--type-style('expressive-heading-05', true);
   }
 
   .ibm-type-italic {

--- a/src/components/TypeTester/TypeTester.js
+++ b/src/components/TypeTester/TypeTester.js
@@ -195,11 +195,11 @@ const languageDropdownContent = [
 
 class TypeTester extends Component {
   state = {
-    typeSizeMultiplier: 470,
+    typeSizeMultiplier: 840,
     label: 'IBM Plex Sans',
     variant: 'ibm-plex-sans',
     lastVariant: 'ibm-plex-sans',
-    fontWeight: 400,
+    fontWeight: 300,
     text: languageSample.find(el => el.language === 'latin').content,
     openDropdown: null,
   };

--- a/src/components/TypeTester/TypeTester.js
+++ b/src/components/TypeTester/TypeTester.js
@@ -3,9 +3,9 @@
 import React, { Component } from 'react';
 import classnames from 'classnames';
 import Dropdown from 'carbon-components-react/lib/components/Dropdown';
+import Slider from 'carbon-components-react/lib/components/Slider';
 import Textarea from 'react-textarea-autosize';
 import { settings } from 'carbon-components';
-import InputRange from '../InputRange/InputRange';
 
 const { prefix } = settings;
 
@@ -314,14 +314,14 @@ class TypeTester extends Component {
             />
           </div>
           <div className={`${prefix}--input-range-wrapper`}>
-            <InputRange
-              className={`${prefix}--input-range`}
+            <Slider
               min={100}
               max={1600}
               value={this.state.typeSizeMultiplier}
               onChange={e => {
-                this.setState({ typeSizeMultiplier: Number(e.target.value) });
+                this.setState({ typeSizeMultiplier: Number(e.value) });
               }}
+              hideTextInput
             />
           </div>
         </div>

--- a/src/components/TypeTester/_type-tester.scss
+++ b/src/components/TypeTester/_type-tester.scss
@@ -118,7 +118,6 @@ $font-prefix: '/fonts';
     box-sizing: border-box;
     display: flex;
     align-items: center;
-    padding: 0 $spacing-05;
     background-color: $ui-02;
     width: 100%;
     height: 3rem;

--- a/src/components/TypeTester/_type-tester.scss
+++ b/src/components/TypeTester/_type-tester.scss
@@ -124,6 +124,19 @@ $font-prefix: '/fonts';
     height: 3rem;
     border-bottom: 1px solid $carbon--gray-20;
 
+    .#{$prefix}--form-item {
+      flex-direction: row;
+      align-items: center;
+
+      .#{$prefix}--slider-container {
+        width: 100%;
+      }
+
+      .#{$prefix}--slider__range-label {
+        display: none;
+      }
+    }
+
     .#{$prefix}--input-range {
       outline: none;
     }

--- a/src/pages/elements/typeface.mdx
+++ b/src/pages/elements/typeface.mdx
@@ -27,7 +27,7 @@ beliefs and design principles.
   <AnchorLink>Feedback & questions</AnchorLink>
 </AnchorLinks>
 
-<Video vimeoId="276055433" />
+<Video vimeoId="337384869" />
 
 ## Resources
 


### PR DESCRIPTION
Closes #84
Closes #130 
Closes #131 

This PR addresses several style issues on the Typeface page

#### Changelog

**New**

- responsive font size (values lifted from current IDL site)

**Changed**

- Replace `<InputRange>` with Carbon `<Slider>`
- typeface page lead video ID