### PR TITLE
fix(philosophy): enable fluid type mixin

### DIFF
--- a/src/styles/_philosophy.scss
+++ b/src/styles/_philosophy.scss
@@ -6,7 +6,7 @@
 }
 
 .bx--type-expressive-heading-03 p {
-  @include carbon--type-style('expressive-heading-03');
+  @include carbon--type-style('expressive-heading-03', true);
 }
 
 //---------------------------------------


### PR DESCRIPTION
Closes #136

This PR enables the `fluid` option for the type mixin for body copy on the Philosophy page