### PR TITLE
chore(url): update Digital Design Kit url

### DIFF
--- a/src/pages/index.mdx
+++ b/src/pages/index.mdx
@@ -23,7 +23,7 @@ export default HomepageTemplate;
       title="Explore & Create"
       actionIcon="resources"
       identityIcon="images/SketchIcon.svg"
-      link="https://www.ibm.com/standards/web/design-kit/"
+      link="https://www.ibm.com/standards/web/getting-started/designers.html#get-the-kit"
       target="_blank"
     />
   </Column>


### PR DESCRIPTION
This updates the Design Kit card url on the homepage. Information for the Digital Design Kit has been moved to [Getting Started: Designers](https://www.ibm.com/standards/web/getting-started/designers.html#get-the-kit) and the original page has been removed from the site.

![Screen Shot 2019-08-02 at 11 09 46 AM](https://user-images.githubusercontent.com/909118/62379977-21a6d380-b516-11e9-98e1-4fcf14cd0d20.png)


#### Changelog

**Changed**

- Design Kit card url [kennylam@dd2ef1ba9d17cbea9293134f8f6749c564ebc901]

