### PR TITLE
fix(homepage-video): reset mobile margin

### DIFF
--- a/src/components/HomepageVideo/_homepage-video.scss
+++ b/src/components/HomepageVideo/_homepage-video.scss
@@ -44,9 +44,9 @@
   width: 100%;
   height: 100%;
   flex-direction: column;
-  margin: 0;
 
   @include carbon--breakpoint('md') {
+    margin: 0;
     flex-direction: row;
     justify-content: flex-end;
   }


### PR DESCRIPTION
Closes #149

This PR fixes the mobile margins for the homepage video CTA