### PR TITLE
fix(non-latin-script): avoid script cutoff

### DIFF
--- a/src/components/NonLatinScripts/_non-latin-script.scss
+++ b/src/components/NonLatinScripts/_non-latin-script.scss
@@ -85,121 +85,33 @@ $font-prefix: '/fonts';
   border: none;
   background-color: transparent;
   outline: none;
-  height: 1.5em;
-  padding: 0;
-  padding-bottom: $spacing-03;
-  padding-top: $spacing-05;
   border-width: 0;
-  margin-bottom: 0;
-  margin-top: 0;
+  margin-bottom: $spacing-03;
   font-weight: 400 !important;
-
-  &.rtl {
-    direction: rtl;
-  }
-
-  @include carbon--breakpoint('md') {
-    margin-top: -0.5rem;
-    margin-bottom: $spacing-03 !important;
-  }
-
-  @include carbon--breakpoint('lg') {
-    margin-top: -1.5rem;
-    margin-bottom: $spacing-03 !important;
-  }
-
   width: 100%;
   color: $carbon--gray-90;
   -webkit-text-fill-color: $carbon--gray-90; // Needs manual autoprefixing
-  line-height: 2em; // Fix weird font-cropping issue on Chrome
 
   &::selection {
     background: $carbon--purple-20;
   }
 
-  // safari wrong height fix
-  @include carbon--breakpoint-down('md') {
-    line-height: 1.5em;
-    margin-bottom: $spacing-05 !important;
-    padding-bottom: $spacing-05;
-  }
-
-  @media not all and (min-resolution: 0.001dpcm) {
-    line-height: 1.5em;
-    margin-bottom: $spacing-05 !important;
-    padding-bottom: $spacing-05;
-  }
-
-  @media screen and (min-color-index: 0) and(-webkit-min-device-pixel-ratio:0) {
-    line-height: 100%;
+  &.rtl {
+    direction: rtl;
   }
 }
 
-.#{$prefix}--non-latin-type-example-devanagari {
-  margin-top: 0rem !important;
-  margin-bottom: $spacing-05;
-  padding-top: 0rem !important;
-  padding-bottom: 0;
-
-  @include carbon--breakpoint('md') {
-    padding-top: $spacing-05 !important;
-  }
-
-  @include carbon--breakpoint-down('md') {
-    margin-top: 0rem !important;
-    margin-bottom: $spacing-05;
-    line-height: 1.5em;
-    padding-bottom: 0;
-  }
-
-  @media screen and (min-color-index: 0) and(-webkit-min-device-pixel-ratio:0) {
-    margin-top: 0rem !important;
-    margin-bottom: $spacing-05;
-    line-height: 1.5em;
-  }
+.#{$prefix}--non-latin-type-example-devanagari,
+.#{$prefix}--non-latin-type-example-arabic {
+  height: 100%;
 }
 
 .#{$prefix}--non-latin-type-example-thai {
-  padding-bottom: $spacing-05 !important;
-  margin-bottom: $spacing-05 !important;
-  line-height: 1.5em !important;
-  line-height: 2em !important;
-
-  // safari cuts thai fonts off, this is a workaround
-  @media not all and (min-resolution: 0.001dpcm) {
-    line-height: 1.5em !important;
-  }
+  line-height: 1.5;
 }
 
-.#{$prefix}--non-latin-type-example-arabic {
-  margin-bottom: 0 !important;
-  padding-bottom: $spacing-07;
-  line-height: 3em;
-  height: 2em;
-
-  @include carbon--breakpoint('md') {
-    margin-top: $spacing-05;
-    padding-bottom: $spacing-09;
-    height: 1.5em;
-  }
-
-  // safari cuts thai fonts off, this is a workaround
-  @media not all and (min-resolution: 0.001dpcm) {
-    line-height: 1.5em;
-    height: 1.75em;
-  }
-}
-
-.#{$prefix}--non-latin-type-example-cyrillic {
-  @media not all and (min-resolution: 0.001dpcm) {
-    padding-top: 0;
-    padding-bottom: 0;
-  }
-
-  @media screen and (min-color-index: 0) and(-webkit-min-device-pixel-ratio:0) {
-    padding-top: 0;
-    padding-bottom: 0;
-  }
+.#{$prefix}--non-latin-type-example-thai-looped {
+  height: 100%;
 }
 
 .#{$prefix}--non-latin-outer-spacing {

--- a/src/components/TypeFaceSubFamilies/TypefaceSubFamilies.js
+++ b/src/components/TypeFaceSubFamilies/TypefaceSubFamilies.js
@@ -79,6 +79,7 @@ export default class TypefaceSubFamilies extends React.Component {
         <div className={`${prefix}--subfamilies-dropdown-container`}>
           <div className={classNamesMenuDropdown}>
             <Dropdown
+              id={`${prefix}--subfamilies-dropdown`}
               items={fontVariants}
               label={this.state.fontVariantLabel}
               selected={this.state.fontVariant}
@@ -97,8 +98,9 @@ export default class TypefaceSubFamilies extends React.Component {
           </div>
         </div>
         <div className={classNamesMenuTabs}>
-          {fontVariants.map(fontVariant => (
+          {fontVariants.map((fontVariant, i) => (
             <button
+              key={`${fontVariant}-${i}`}
               type="button"
               className={
                 fontVariant.label === this.state.fontVariantLabel

--- a/src/components/TypeTester/TypeTester.js
+++ b/src/components/TypeTester/TypeTester.js
@@ -193,7 +193,7 @@ const languageDropdownContent = [
   return variant;
 });
 
-class TypeTester extends Component {
+export default class TypeTester extends Component {
   state = {
     typeSizeMultiplier: 840,
     label: 'IBM Plex Sans',
@@ -291,6 +291,7 @@ class TypeTester extends Component {
         <div className={`${prefix}--type-tester-menu`}>
           <div className="dropdown_wrapper">
             <Dropdown
+              id={`${prefix}--type-tester-language-dropdown`}
               items={languageDropdownContent}
               label={this.state.label}
               onChange={this.onLanguageDropdownChange}
@@ -302,6 +303,7 @@ class TypeTester extends Component {
               open={this.state.openDropdown === 'language-dropdown'}
             />
             <Dropdown
+              id={`${prefix}--type-tester-weight-dropdown`}
               items={this.getWeightsForLanguage()}
               label={this.getLanguageForWeight(this.state.fontWeight)}
               onChange={this.onFontWeightDropdownChange}
@@ -344,5 +346,3 @@ class TypeTester extends Component {
 }
 
 TypeTester.propTypes = {};
-
-export default TypeTester;


### PR DESCRIPTION
Closes #138

This PR modifies the non-Latin script stylesheet to avoid cutoff issues on multiple browsers

#### Changelog

**New**

- set custom height rules and line height rules for Devanagari, Arabic, Thai

**Changed**

- replace script specific style overrides and set consistent spacing rules
- remove console errors

**Removed**

- conflicting `!important` overrides