### PR TITLE
fix(index): resolve homepage layout bugs

### DIFF
--- a/src/components/Carousel/_carousel.scss
+++ b/src/components/Carousel/_carousel.scss
@@ -13,33 +13,30 @@
       height: 100%;
       white-space: nowrap;
 
-      & img {
-        height: auto;
-        width: 100%;
-        display: inline;
+      img {
+        height: 100%;
+        object-fit: cover;
         transition: transform 700ms cubic-bezier(0.5, 0, 0.1, 1);
       }
     }
   }
 
   &.fade {
-    padding-bottom: 100%;
+    height: 100%;
 
     .#{$prefix}--carousel-slide-wrapper {
       height: 100%;
       position: absolute;
 
-      .#{$prefix}--carousel-slide {
-        & img {
-          position: absolute;
-          top: 0;
-          left: 0;
-          opacity: 0;
-          transition: opacity 700ms cubic-bezier(0.5, 0, 0.1, 1);
+      .#{$prefix}--carousel-slide img {
+        position: absolute;
+        top: 0;
+        left: 0;
+        opacity: 0;
+        transition: opacity 700ms cubic-bezier(0.5, 0, 0.1, 1);
 
-          &:first-child {
-            opacity: 1;
-          }
+        &:first-child {
+          opacity: 1;
         }
       }
     }

--- a/src/components/HomepageTile/HomepageTile.js
+++ b/src/components/HomepageTile/HomepageTile.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useLayoutEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { settings } from 'carbon-components';
 import { Launch20, ArrowRight24, Error20 } from '@carbon/icons-react';
@@ -34,11 +34,17 @@ const HomepageTile = ({
   const [width, setWidth] = useState(
     typeof window !== 'undefined' && window.innerWidth
   );
+  const [showTile, setShowTile] = useState(false);
   const handleResize = () => setWidth(window.innerWidth);
-  useEffect(() => {
+  useLayoutEffect(() => {
+    setWidth(typeof window !== 'undefined' && window.innerWidth);
+    if (!width) {
+      return;
+    }
+    setShowTile(true);
     window.addEventListener('resize', handleResize);
     return () => window.removeEventListener('resize', handleResize);
-  });
+  }, [width]);
   const getBreakpoints = ({ viewportWidth, points }) =>
     Object.entries(points).reduce(
       (breakpointNames, [breakpointName, breakpointValue]) => {
@@ -123,82 +129,84 @@ const HomepageTile = ({
   };
 
   return (
-    <>
-      {children ? (
-        <div
-          className={
-            theme === 'dark'
-              ? `${prefix}--homepage-idl-tile ${prefix}--homepage-idl-tile__dark`
-              : `${prefix}--homepage-idl-tile`
-          }
-          style={ratioStyle}
-          href={link}
-          target={target}>
-          <div
-            className={`${prefix}--homepage-idl-tile-background`}
-            style={backgroundStyle}
-          />
-          <div className={`${prefix}--homepage-idl-tile-nested-content`}>
-            {children}
-          </div>
-        </div>
-      ) : (
-        <a
-          className={
-            theme === 'dark'
-              ? `${prefix}--homepage-idl-tile ${prefix}--homepage-idl-tile__dark`
-              : `${prefix}--homepage-idl-tile`
-          }
-          style={ratioStyle}
-          href={link}
-          target={target}>
+    showTile && (
+      <>
+        {children ? (
           <div
             className={
-              hoverDark
-                ? `${prefix}--homepage-idl-tile-hover ${prefix}--homepage-idl-tile-hover__dark`
-                : `${prefix}--homepage-idl-tile-hover`
+              theme === 'dark'
+                ? `${prefix}--homepage-idl-tile ${prefix}--homepage-idl-tile__dark`
+                : `${prefix}--homepage-idl-tile`
             }
-          />
-          <div
-            className={`${prefix}--homepage-idl-tile-background`}
-            style={backgroundStyle}
-          />
-          <div
-            className={
-              contentOnHover
-                ? `${prefix}--homepage-idl-tile-content ${prefix}--homepage-idl-tile-content-on-hover-only`
-                : `${prefix}--homepage-idl-tile-content`
-            }
-            style={transparentImageStyle}>
+            style={ratioStyle}
+            href={link}
+            target={target}>
             <div
-              className={
-                disabled
-                  ? `${prefix}--homepage-idl-tile-title ${prefix}--homepage-idl-tile-title--disabled`
-                  : `${prefix}--homepage-idl-tile-title`
-              }>
-              <div className={`${prefix}--type-body-long-01`}>{subtitle}</div>
-              <div className={`${prefix}--type-expressive-heading-03`}>
-                {title}
-              </div>
+              className={`${prefix}--homepage-idl-tile-background`}
+              style={backgroundStyle}
+            />
+            <div className={`${prefix}--homepage-idl-tile-nested-content`}>
+              {children}
             </div>
-            {identityIcon ? (
-              <div className={`${prefix}--homepage-idl-tile-identity-icon`}>
-                <img src={identityIcon} alt="identity-icon" />
-              </div>
-            ) : null}
+          </div>
+        ) : (
+          <a
+            className={
+              theme === 'dark'
+                ? `${prefix}--homepage-idl-tile ${prefix}--homepage-idl-tile__dark`
+                : `${prefix}--homepage-idl-tile`
+            }
+            style={ratioStyle}
+            href={link}
+            target={target}>
             <div
               className={
-                disabled
-                  ? `${prefix}--homepage-idl-tile-action-icon ${prefix}--homepage-idl-tile-action-icon--disabled`
-                  : `${prefix}--homepage-idl-tile-action-icon`
+                hoverDark
+                  ? `${prefix}--homepage-idl-tile-hover ${prefix}--homepage-idl-tile-hover__dark`
+                  : `${prefix}--homepage-idl-tile-hover`
               }
-              style={{ fill: theme === 'dark' ? '#ffffff' : '#282828' }}>
-              {getActionIcon(actionIcon)}
+            />
+            <div
+              className={`${prefix}--homepage-idl-tile-background`}
+              style={backgroundStyle}
+            />
+            <div
+              className={
+                contentOnHover
+                  ? `${prefix}--homepage-idl-tile-content ${prefix}--homepage-idl-tile-content-on-hover-only`
+                  : `${prefix}--homepage-idl-tile-content`
+              }
+              style={transparentImageStyle}>
+              <div
+                className={
+                  disabled
+                    ? `${prefix}--homepage-idl-tile-title ${prefix}--homepage-idl-tile-title--disabled`
+                    : `${prefix}--homepage-idl-tile-title`
+                }>
+                <div className={`${prefix}--type-body-long-01`}>{subtitle}</div>
+                <div className={`${prefix}--type-expressive-heading-03`}>
+                  {title}
+                </div>
+              </div>
+              {identityIcon ? (
+                <div className={`${prefix}--homepage-idl-tile-identity-icon`}>
+                  <img src={identityIcon} alt="identity-icon" />
+                </div>
+              ) : null}
+              <div
+                className={
+                  disabled
+                    ? `${prefix}--homepage-idl-tile-action-icon ${prefix}--homepage-idl-tile-action-icon--disabled`
+                    : `${prefix}--homepage-idl-tile-action-icon`
+                }
+                style={{ fill: theme === 'dark' ? '#ffffff' : '#282828' }}>
+                {getActionIcon(actionIcon)}
+              </div>
             </div>
-          </div>
-        </a>
-      )}
-    </>
+          </a>
+        )}
+      </>
+    )
   );
 };
 

--- a/src/components/HomepageTile/HomepageTile.js
+++ b/src/components/HomepageTile/HomepageTile.js
@@ -31,7 +31,9 @@ const HomepageTile = ({
   target,
   children,
 }) => {
-  const [width, setWidth] = useState(window.innerWidth);
+  const [width, setWidth] = useState(
+    typeof window !== 'undefined' && window.innerWidth
+  );
   const handleResize = () => setWidth(window.innerWidth);
   useEffect(() => {
     window.addEventListener('resize', handleResize);

--- a/src/pages/index.mdx
+++ b/src/pages/index.mdx
@@ -41,7 +41,7 @@ export default HomepageTemplate;
     <HomepageTile
       ratio="1:1" 
       theme="dark"
-      subtitle="GitHub repo"
+      subtitle="GitHub Repo"
       title="Design & development"
       actionIcon="resources"
       identityIcon="images/GitHubIcon.svg"
@@ -149,9 +149,9 @@ export default HomepageTemplate;
     image="images/product-gallery.jpg"
     actionIcon="no-icon">
     <HomepageTile
-      ratio="4:1"
+      ratio="4:1" 
       theme="dark"
-      subtitle="Photography"
+      subtitle="Gallery"
       title="IBM Services"
       actionIcon="article"
       link="https://www.ibm.com/design/language/gallery/"

--- a/src/pages/index.mdx
+++ b/src/pages/index.mdx
@@ -149,7 +149,7 @@ export default HomepageTemplate;
     image="images/product-gallery.jpg"
     actionIcon="no-icon">
     <HomepageTile
-      ratio="4:1" 
+      ratio={{ default: '2:1', md: '4:1', }}
       theme="dark"
       subtitle="Gallery"
       title="IBM Services"
@@ -163,7 +163,7 @@ export default HomepageTemplate;
 <Row>
   <Column colLg={12} noGutterSm>
     <HomepageTile
-      ratio="16:9"
+      ratio={{ default: '1:2', md: '16:9' }}
       image="images/landing-photography-gallery-2.jpg"
       actionIcon="no-icon">
       <Carousel id="c1" count="1 2" nav={false} fade={true} autoplay>
@@ -177,7 +177,7 @@ export default HomepageTemplate;
         />
       </Carousel>
       <HomepageTile
-        ratio="6:1" 
+        ratio={{ default: '2:1', md: '6:1' }}
         theme="dark"
         subtitle="Elements"
         title="Photography"
@@ -191,12 +191,12 @@ export default HomepageTemplate;
 <Row className="homepage-tiles--end">
   <Column colLg={8} noGutterSm>
     <HomepageTile
-      ratio="1:1"
+      ratio={{ default: '1:2', md: '1:1' }}
       image="images/landing-gallery-watson-duo-phone.jpg"
       actionIcon="no-icon"
     >
       <HomepageTile
-        ratio="4:1" 
+        ratio={{ default: '2:1', md: '4:1' }}
         theme="dark"
         subtitle="Case Study"
         title="Coming soon"

--- a/src/pages/index.mdx
+++ b/src/pages/index.mdx
@@ -193,7 +193,8 @@ export default HomepageTemplate;
     <HomepageTile
       ratio="1:1"
       image="images/landing-gallery-watson-duo-phone.jpg"
-    actionIcon="no-icon">
+      actionIcon="no-icon"
+    >
       <HomepageTile
         ratio="4:1" 
         theme="dark"
@@ -201,7 +202,7 @@ export default HomepageTemplate;
         title="Coming soon"
         actionIcon="disabled"
         disabled
-    />
+      />
     </HomepageTile>
   </Column>
   <Column colLg={4} colMd={4} noGutterSm>

--- a/src/pages/index.mdx
+++ b/src/pages/index.mdx
@@ -143,7 +143,7 @@ export default HomepageTemplate;
       target="_blank"
     />
   </Column>
-  <Column colLg={8} noGutterLg>
+  <Column colLg={8} noGutterSm>
   <HomepageTile
     ratio="1:1"
     image="images/product-gallery.jpg"
@@ -161,7 +161,7 @@ export default HomepageTemplate;
   </Column>
 </Row>
 <Row>
-  <Column colLg={12} noGutterLg>
+  <Column colLg={12} noGutterSm>
     <HomepageTile
       ratio="16:9"
       image="images/landing-photography-gallery-2.jpg"
@@ -189,10 +189,10 @@ export default HomepageTemplate;
   </Column>
 </Row>
 <Row className="homepage-tiles--end">
-  <Column colLg={8} noGutterLg>
-  <HomepageTile
-    ratio="1:1"
-    image="images/landing-gallery-watson-duo-phone.jpg"
+  <Column colLg={8} noGutterSm>
+    <HomepageTile
+      ratio="1:1"
+      image="images/landing-gallery-watson-duo-phone.jpg"
     actionIcon="no-icon">
       <HomepageTile
         ratio="4:1" 

--- a/src/pages/index.mdx
+++ b/src/pages/index.mdx
@@ -164,7 +164,6 @@ export default HomepageTemplate;
   <Column colLg={12} noGutterSm>
     <HomepageTile
       ratio={{ default: '1:2', md: '16:9' }}
-      image="images/landing-photography-gallery-2.jpg"
       actionIcon="no-icon">
       <Carousel id="c1" count="1 2" nav={false} fade={true} autoplay>
         <img

--- a/src/pages/index.mdx
+++ b/src/pages/index.mdx
@@ -176,7 +176,7 @@ export default HomepageTemplate;
         />
       </Carousel>
       <HomepageTile
-        ratio={{ default: '2:1', md: '6:1' }}
+        ratio={{ default: '2:1', md: '4:1', lg: '6:1' }}
         theme="dark"
         subtitle="Elements"
         title="Photography"


### PR DESCRIPTION
Closes #108

This PR addresses several homepage layout issues related to card ratios at different screen sizes, image ordering, and spacing

#### Changelog

**New**

- `<HomepageTile>` supports an object of ratios for the `ratio` prop (`ratio={{ default: '1:1', sm: '2:1', md: '3:2' }}`), linked to Carbon breakpoints

**Changed**

- avoid column gutter at small screen sizes
- copy fixes