### PR TITLE
fix(pictograms): rename page

### DIFF
--- a/src/data/nav-items.yaml
+++ b/src/data/nav-items.yaml
@@ -29,7 +29,7 @@
     - title: App icons
       path: /elements/app-icons/design
     - title: Pictograms
-      path: /elements/pictograms/overview
+      path: /elements/pictograms/design
     - title: Photography
       path: /elements/photography/overview
     - title: Motion

--- a/src/pages/elements/pictograms/contribute.mdx
+++ b/src/pages/elements/pictograms/contribute.mdx
@@ -1,6 +1,6 @@
 ---
 title: Pictograms
-tabs: [Overview, Usage, Contribute]
+tabs: [Design, Usage, Contribute]
 ---
 
 <PageDescription>

--- a/src/pages/elements/pictograms/design.mdx
+++ b/src/pages/elements/pictograms/design.mdx
@@ -1,6 +1,6 @@
 ---
 title: Pictograms
-tabs: [Overview, Usage, Contribute]
+tabs: [Design, Usage, Contribute]
 ---
 
 import { AnchorLinks, AnchorLink } from 'gatsby-theme-carbon';

--- a/src/pages/elements/pictograms/usage.mdx
+++ b/src/pages/elements/pictograms/usage.mdx
@@ -1,6 +1,6 @@
 ---
 title: Pictograms
-tabs: [Overview, Usage, Contribute]
+tabs: [Design, Usage, Contribute]
 ---
 
 import { Bee32 } from '@carbon/icons-react';


### PR DESCRIPTION
Closes #164

This PR renames the "overview" tab for the pictograms page to "design"