### PR TITLE
fix(non-latin-script): increase line height for non latin type examples

### DIFF
--- a/src/components/NonLatinScripts/_non-latin-script.scss
+++ b/src/components/NonLatinScripts/_non-latin-script.scss
@@ -87,6 +87,7 @@ $font-prefix: '/fonts';
   outline: none;
   border-width: 0;
   margin-bottom: $spacing-03;
+  line-height: 1.5;
   font-weight: 400 !important;
   width: 100%;
   color: $carbon--gray-90;
@@ -104,10 +105,6 @@ $font-prefix: '/fonts';
 .#{$prefix}--non-latin-type-example-devanagari,
 .#{$prefix}--non-latin-type-example-arabic {
   height: 100%;
-}
-
-.#{$prefix}--non-latin-type-example-thai {
-  line-height: 1.5;
 }
 
 .#{$prefix}--non-latin-type-example-thai-looped {


### PR DESCRIPTION
Closes #138

This PR increases the line height for all non-Latin type examples