### PR TITLE
fix(pictograms): add links for design and production guidelines

### DIFF
--- a/src/pages/elements/pictograms/contribute.mdx
+++ b/src/pages/elements/pictograms/contribute.mdx
@@ -23,9 +23,9 @@ and work well in presentations and marketing communications.
 
 Don’t see the pictogram you need in the library? Make your own! Follow these guidelines to ensure visual consistency and proper formatting.
 
-- All pictograms should be unique and not redundant with any existing pictograms in the system. Look through the pictograms in the IBM Design Sketch kit to ensure that your proposed new pictogram is not already represented.
-- All pictograms should adhere to the IBM Design Language visual style.
-- All pictograms should comply with IBM accessibility standards.
+- All pictograms should be unique and not redundant with any existing pictograms in the system. Look through the pictograms in the [IBM Design Sketch kit](https://ibm.com/standards/web/design-kit) to ensure that your proposed new pictogram is not already represented.
+- All pictograms should adhere to the [IBM Design Language visual style](/elements/pictograms/design).
+- All pictograms should comply with IBM [accessibility standards](https://www.carbondesignsystem.com/guidelines/accessibility/overview).
 - All pictograms should be usable across all supported platforms and devices.
 - All pictograms should be understandable by a global audience of users, regardless of nationality or language.
 


### PR DESCRIPTION
Closes #182

This PR adds missing links for the Design and production guidelines section on the pictograms page