### PR TITLE
fix(typeface-sub-families): avoid line breaks on mobile

### DIFF
--- a/src/components/TypeFaceSubFamilies/_typeface-sub-families.scss
+++ b/src/components/TypeFaceSubFamilies/_typeface-sub-families.scss
@@ -88,5 +88,7 @@
 }
 
 .#{$prefix}--subfamilies-TypeTesterExample__column {
-  width: 50%;
+  @include carbon--breakpoint('md') {
+    width: 50%;
+  }
 }


### PR DESCRIPTION
Closes #166

This PR changes the typeface sub families styles to apply column width only on larger screen sizes