### PR TITLE
fix(Carousel): use camelcased autoplay attribute

### DIFF
--- a/src/components/Carousel/Carousel.js
+++ b/src/components/Carousel/Carousel.js
@@ -40,7 +40,7 @@ export default class Carousel extends React.Component {
 
     this.state = {
       checkedRadio: 1,
-      autoplay: !!this.props.autoplay,
+      autoplay: !!this.props.autoPlay,
       items: numArr,
     };
   }
@@ -54,7 +54,6 @@ export default class Carousel extends React.Component {
       slide.addEventListener('touchmove', this.touchMove, false);
       slide.addEventListener('mousedown', this.mouseStart);
       slide.addEventListener('mousemove', this.mouseMove);
-
       if (this.state.autoplay) AP_ID = setInterval(this.nextSlide, 6000);
     }
   }

--- a/src/pages/elements/color.mdx
+++ b/src/pages/elements/color.mdx
@@ -64,7 +64,7 @@ A vibrant set of blues is the centerpoint of the color palette. When combined wi
 </Column>
 <Column colMd={4} colLg={6}  className="color-logo-carousel">
 
-<Carousel id="c1" count="1 2 3 4 5 6 7 8 9" nav={false} fade={true} autoplay>
+<Carousel id="c1" count="1 2 3 4 5 6 7 8 9" nav={false} fade={true} autoPlay>
 
 ![Spaceman](/images/Spaceman.svg)
 

--- a/src/pages/index.mdx
+++ b/src/pages/index.mdx
@@ -165,7 +165,7 @@ export default HomepageTemplate;
     <HomepageTile
       ratio={{ default: '1:2', md: '16:9' }}
       actionIcon="no-icon">
-      <Carousel id="c1" count="1 2" nav={false} fade={true} autoplay>
+      <Carousel id="c1" count="1 2" nav={false} fade={true} autoPlay>
         <img
           src="images/landing-photography-gallery-1-mobile.jpg"
           alt="alt text"


### PR DESCRIPTION
Closes #246

This PR changes the Carousel component initial `autoplay` state to read from `props.autoPlay` instead of `props.autoplay`. The homepage and color page carousels should now autoplay properly