### PR TITLE
chore(index): color palette asset path change

### DIFF
--- a/src/pages/index.mdx
+++ b/src/pages/index.mdx
@@ -92,7 +92,7 @@ export default HomepageTemplate;
       ratio="1:1" 
       theme="dark"
       hoverDark
-      image="/images/landing-color-grid.svg"
+      image="images/landing-color-grid.svg"
       subtitle="Elements"
       title="Color Palette"
       actionIcon="article"


### PR DESCRIPTION
Closes #245

This PR removes the leading slash on the color palette homepage tile asset. We may need to do this elsewhere in the repo to resolve some missing asset issues