### PR TITLE
fix(type-basics): alignment copy edit

### DIFF
--- a/src/pages/elements/type-basics.mdx
+++ b/src/pages/elements/type-basics.mdx
@@ -381,7 +381,7 @@ Always look for opportunities to create improve rags. Watch out for orphans and 
 
 ## Alignment
 
-Whenever possible, left align copy with other copy, even when it’s in a container element. This create a strong vertical alignment with the text adding in legibility, organization and clarity for a user.
+Whenever possible, left align copy with other copy, even when it’s in a container element. This creates a strong vertical alignment with the text adding in legibility, organization and clarity for a user.
 
 <DoDontExample type="do">
 <ArtDirection>


### PR DESCRIPTION
Closes #261

This PR fixes a typo in the type basics page alignment section copy