### PR TITLE
fix(color-page): prevent carousel from collapsing on mobile

### DIFF
--- a/src/components/Carousel/_carousel.scss
+++ b/src/components/Carousel/_carousel.scss
@@ -14,7 +14,7 @@
       white-space: nowrap;
 
       img {
-        height: 100%;
+        width: 100%;
         object-fit: cover;
         transition: transform 700ms cubic-bezier(0.5, 0, 0.1, 1);
       }

--- a/src/components/Carousel/_carousel.scss
+++ b/src/components/Carousel/_carousel.scss
@@ -26,7 +26,7 @@
 
     .#{$prefix}--carousel-slide-wrapper {
       height: 100%;
-      position: absolute;
+      padding-bottom: 100%;
 
       .#{$prefix}--carousel-slide img {
         position: absolute;

--- a/src/styles/_homepage.scss
+++ b/src/styles/_homepage.scss
@@ -1,3 +1,17 @@
 .homepage-tiles--end {
   margin-bottom: 10rem;
 }
+
+.#{$prefix}--homepage-idl-tile-nested-content
+  .#{$prefix}--carousel.fade
+  .#{$prefix}--carousel-slide-wrapper {
+  height: 100%;
+  position: absolute;
+  padding-bottom: 0;
+
+  .#{$prefix}--carousel-slide img {
+    height: 100%;
+    object-fit: cover;
+    transition: transform 700ms cubic-bezier(0.5, 0, 0.1, 1);
+  }
+}


### PR DESCRIPTION
Closes #263

This PR adjusts carousel styles so that absolute positioned `img` children in the carousel will not collapse due to its parent being relative positioned and having percentage based height. We set padding instead of height to maintain the parent container's dimensions when the `img` children are absolutely positioned