### PR TITLE
fix(SwatchPaletteWidget): restore format switching functionality

### DIFF
--- a/src/components/SwatchPaletteWidget/SwatchPaletteWidget.js
+++ b/src/components/SwatchPaletteWidget/SwatchPaletteWidget.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { ContentSwitcher, Switch } from 'carbon-components-react';
 import { settings } from 'carbon-components';
@@ -25,70 +25,54 @@ const colorFormats = [
   },
 ];
 
-class SwatchPaletteWidget extends Component {
-  state = {
-    format: 'hex',
-  };
+export default function SwatchPaletteWidget(props) {
+  const [format, setFormat] = useState('hex');
+  const switchFormat = index => setFormat(colorFormats[index].value);
 
-  switchFormat = format => {
-    this.setState({
-      format: format.name,
-    });
-  };
-
-  render() {
-    // palettes is array of colors to be controlled by ContentSwitcher (see PALETTES object in SwatchPalette component)
-    // add '-bw' to color name to get black and white bars appearing at top and bottom of color palette
-    // top value sets top of sticky switcher buttons (only required if not zero)
-    const { palettes, top } = this.props;
-
-    return (
-      <div className={`${prefix}--swatch-palettes-container`}>
-        <div className="sticky-container" style={{ top }}>
-          <div className={`${prefix}--row`}>
-            <div
-              className={`${prefix}--col-lg-4 ${prefix}--col-md-4 ${prefix}--col-no-gutter`}>
-              <ContentSwitcher
-                className={`${prefix}--swatch-palettes__format-switcher`}
-                onChange={this.switchFormat}>
-                {colorFormats.map(format => (
-                  <Switch
-                    key={format.value}
-                    name={format.value}
-                    text={format.label}
-                  />
-                ))}
-              </ContentSwitcher>
-            </div>
+  // palettes is an array of colors to be controlled by ContentSwitcher (see PALETTES object in SwatchPalette component)
+  // add '-bw' to color name to get black and white bars appearing at top and bottom of color palette
+  // top value sets top of sticky switcher buttons (only required if not zero)
+  const { palettes, top } = props;
+  return (
+    <div className={`${prefix}--swatch-palettes-container`}>
+      <div className="sticky-container" style={{ top }}>
+        <div className={`${prefix}--row`}>
+          <div
+            className={`${prefix}--col-lg-4 ${prefix}--col-md-4 ${prefix}--col-no-gutter`}>
+            <ContentSwitcher
+              className={`${prefix}--swatch-palettes__format-switcher`}
+              onChange={switchFormat}>
+              {colorFormats.map(({ value, label }) => (
+                <Switch key={value} name={value} text={label} />
+              ))}
+            </ContentSwitcher>
           </div>
         </div>
-        {palettes.map((palette, i) => (
-          <div key={i} className={`${prefix}--row`}>
-            <div
-              className={`${prefix}--col-lg-12 ${prefix}--col-md-8 ${prefix}--col-no-gutter ${prefix}--swatch-palettes`}>
-              {palette.map(color => {
-                const col = color.split('-');
-                const showBW = col[1] === 'bw';
-                return (
-                  <SwatchPalette
-                    key={col[0]}
-                    palette={col[0]}
-                    format={this.state.format}
-                    showBW={showBW}
-                  />
-                );
-              })}
-            </div>
-          </div>
-        ))}
       </div>
-    );
-  }
+      {palettes.map((palette, i) => (
+        <div key={i} className={`${prefix}--row`}>
+          <div
+            className={`${prefix}--col-lg-12 ${prefix}--col-md-8 ${prefix}--col-no-gutter ${prefix}--swatch-palettes`}>
+            {palette.map(color => {
+              const col = color.split('-');
+              const showBW = col[1] === 'bw';
+              return (
+                <SwatchPalette
+                  key={col[0]}
+                  palette={col[0]}
+                  format={format}
+                  showBW={showBW}
+                />
+              );
+            })}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
 }
 
 SwatchPaletteWidget.propTypes = {
   palettes: PropTypes.array.isRequired,
   top: PropTypes.string,
 };
-
-export default SwatchPaletteWidget;


### PR DESCRIPTION
Closes #273

Related https://github.com/carbon-design-system/carbon-website/pull/124/

This PR modifies the content switcher in `<SwatchPaletteWidget>` to account for upstream breaking changes (ref https://github.com/carbon-design-system/carbon/pull/3302/). Since we no longer receive the deprecated `name` prop and only receive selected index on change, we use the existing hard coded `colorFormats` array to show the correct color info

#### Changelog

**Changed**

- color format switcher logic (now relying on returned index instead of switch name due to #3302)