### PR TITLE
docs: fix icon size typo

### DIFF
--- a/src/pages/elements/icons/usage.mdx
+++ b/src/pages/elements/icons/usage.mdx
@@ -34,7 +34,7 @@ Icons have been designed to work best in four sizes: 16px, 20px, 24px, and 32px.
 | --------------------------------------------- | ------------ | ------- | --------- | ------------- | ---------- |
 | 32px                                          | 2px          | 2px     | 28px      | 2px           | —          |
 | 24px                                          | 1.5px        | 1.5px   | 21px      | 1.5px         | —          |
-| <span class="footnote__highlight">0px</span>  | 1.25px       | 1.25px  | 17.5px    | 1.25px        | 16pt       |
+| <span class="footnote__highlight">20px</span> | 1.25px       | 1.25px  | 17.5px    | 1.25px        | 16pt       |
 | <span class="footnote__highlight">16px</span> | 1px          | 1px     | 14px      | 1px           | 14pt       |
 
 <Caption>


### PR DESCRIPTION
👋 I fixed a typo on the icon usage page. I assume `0px` was supposed to be `20px` 😅 
