### PR TITLE
chore: specify node version and update ci version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:8.11
+      - image: circleci/node:8
     working_directory: ~/repo
     steps:
       - checkout

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "private": true,
   "version": "0.0.0",
   "main": "src",
+  "engines": {
+    "node": "^8.16.0"
+  },
   "repository": {
     "url": "git@github.com:carbon-design-system/design-language-website.git",
     "type": "git"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "version": "0.0.0",
   "main": "src",
   "engines": {
-    "node": "^8.16.0"
+    "node": ">=8.16.0"
   },
   "repository": {
     "url": "git@github.com:carbon-design-system/design-language-website.git",


### PR DESCRIPTION
An update dependancy has a minimum node version of `8.12` but because we're tied to `8.11` it fails circle-ci.

This also adds the "engine" key to our package.json to ensure the cloud foundry builder uses the same version as circle-CI