### PR TITLE
chore: disable source-maps in production

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,0 +1,8 @@
+exports.onCreateWebpackConfig = ({ actions, getConfig }) => {
+  // Disable sourcemaps in production
+  if (getConfig().mode === 'production') {
+    actions.setWebpackConfig({
+      devtool: false,
+    });
+  }
+};


### PR DESCRIPTION
Gatsby generates source-maps even production. This is an issue with our dynamic icon strategy which generates hundreds of javascript files.

This removes source-maps in when in production.

also [disabled for Carbon](https://github.com/carbon-design-system/carbon-website/pull/1144)