### PR TITLE
feat: update chart overview cards

### DIFF
--- a/src/components/OverviewCard/OverviewCard.js
+++ b/src/components/OverviewCard/OverviewCard.js
@@ -2,9 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { Link } from 'gatsby';
-import { Tag } from 'carbon-components-react';
+import { Tag, TooltipIcon } from 'carbon-components-react';
 import './overview-card.scss';
 import './overview-card-group.scss';
+import { Launch16 } from '@carbon/icons-react';
 
 export default class OverviewCard extends React.Component {
   static propTypes = {
@@ -21,7 +22,7 @@ export default class OverviewCard extends React.Component {
     href: PropTypes.string,
 
     /**
-     * LTitle
+     * Title
      */
     title: PropTypes.string,
 
@@ -34,17 +35,33 @@ export default class OverviewCard extends React.Component {
      * Specify a custom class
      */
     className: PropTypes.string,
+
+    /**
+     * Tooltip text
+     */
+    tooltipText: PropTypes.string,
   };
 
   static defaultProps = {
     disabled: false,
+    tooltipText: 'Carbon implementation',
   };
 
   render() {
-    const { children, href, title, disabled, className, tag } = this.props;
+    const {
+      children,
+      href,
+      title,
+      disabled,
+      className,
+      tag,
+      tooltipText,
+    } = this.props;
 
     let isLink;
     if (href !== undefined) {
+      // Determines if the link is another page in this repo (will have a relative path === "/")
+      // or from an external site (will start with "h" from "https" therefore first char !== "/")
       isLink = href.charAt(0) === '/';
     }
 
@@ -53,44 +70,53 @@ export default class OverviewCard extends React.Component {
       [`overview-card--disabled`]: disabled,
     });
 
-    const carbonTileclassNames = classnames(
-      [`bx--tile`],
-      [`bx--tile--clickable`]
-    );
+    const carbonTileclassNames = classnames([`bx--tile`], {
+      [`bx--tile--clickable`]: isLink !== false,
+      [`overview-card--outgoing`]: isLink === false,
+    });
+
+    const aspectRatioClassNames = classnames([`bx--aspect-ratio--object`], {
+      [`aspect-ratio__has-tooltip`]: isLink === false,
+    });
 
     const cardContent = (
       <>
         <h4 className="overview-card__title">{title}</h4>
         {tag && <Tag type="teal">{tag}</Tag>}
         <div className="overview-card__img">{children}</div>
+        {isLink === false && (
+          <a
+            className="overview-card__link"
+            target="_blank"
+            rel="noopener noreferrer"
+            href={href}>
+            <TooltipIcon
+              className="overview-card__tooltip"
+              direction="top"
+              align="end"
+              tooltipText={tooltipText}>
+              <Launch16 />
+            </TooltipIcon>
+          </a>
+        )}
       </>
     );
 
     let cardContainer;
-    if (disabled === true) {
-      cardContainer = <div className={carbonTileclassNames}>{cardContent}</div>;
-    } else if (isLink === true) {
+    if (isLink === true) {
       cardContainer = (
         <Link to={href} className={carbonTileclassNames}>
           {cardContent}
         </Link>
       );
     } else {
-      cardContainer = (
-        <a
-          target="_blank"
-          rel="noopener noreferrer"
-          href={href}
-          className={carbonTileclassNames}>
-          {cardContent}
-        </a>
-      );
+      cardContainer = <div className={carbonTileclassNames}>{cardContent}</div>;
     }
 
     return (
       <div className={OverviewCardClassNames}>
         <div className="bx--aspect-ratio bx--aspect-ratio--1x1">
-          <div className="bx--aspect-ratio--object">{cardContainer}</div>
+          <div className={aspectRatioClassNames}>{cardContainer}</div>
         </div>
       </div>
     );

--- a/src/components/OverviewCard/overview-card.scss
+++ b/src/components/OverviewCard/overview-card.scss
@@ -1,5 +1,3 @@
-
-
 .overview-card {
   position: relative;
 }
@@ -71,4 +69,48 @@
 .overview-card--disabled .overview-card__img {
   filter: grayscale(1);
   opacity: 0.3;
+}
+
+//outgoing link
+.bx--aspect-ratio--object.aspect-ratio__has-tooltip {
+  z-index: auto;
+}
+
+.overview-card .bx--tile.overview-card--outgoing:hover {
+  background: $carbon--white-0;
+}
+
+.overview-card
+  .bx--tile.overview-card--outgoing:hover
+  .overview-card__img:after {
+  display: none;
+}
+
+.overview-card__link {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+}
+
+.overview-card__link:hover {
+  background: $hover-ui;
+}
+
+.overview-card__link:focus {
+  outline: 2px solid $focus;
+  outline-offset: -2px;
+}
+
+.overview-card--outgoing .overview-card__link svg {
+  opacity: 0;
+}
+
+.overview-card--outgoing:hover .overview-card__link svg {
+  opacity: 1;
+}
+
+.overview-card__tooltip.bx--tooltip__trigger:not(.bx--btn--icon-only) {
+  height: 2rem;
+  width: 2rem;
+  padding: 0.5rem;
 }


### PR DESCRIPTION
Closes #518 

Makes chart overview cards have a link out button with tooltip like the icon overview cards.

**Changed**

- if link is external, overview card now has a small link at the bottom right corner w/ a launch icon + tooltip on hover (internal links will remain as is)
- made tooltip align at the end bc otherwise it cuts off after a certain breakpoint (`xl`/`1312px`) bc there's not enough margin on the side. This can be seen in the icon overview cards. Not sure if this is the solution we want.  ⬅️ _Any feedback?_
<img width="313" alt="Screen Shot 2020-05-27 at 2 56 58 PM" src="https://user-images.githubusercontent.com/32556167/83066629-f6541e80-a02a-11ea-869b-043ff22d7d63.png">
<img width="353" alt="Screen Shot 2020-05-27 at 3 02 20 PM" src="https://user-images.githubusercontent.com/32556167/83066714-14ba1a00-a02b-11ea-9d60-13d131700d73.png">


