### PR TITLE
fix: illustration isometric page dodont

### DIFF
--- a/src/pages/illustration/isometric-style/design.mdx
+++ b/src/pages/illustration/isometric-style/design.mdx
@@ -153,29 +153,21 @@ Based on the angles of an equilateral triangle, the isometric 2x grid is essenti
 
 Illustrations should snap to the intersections of the isometric grid lines in Adobe Illustrator. The grid gives the precise and engineered aesthetic, which is vital to any IBM illustration.
 
-<Row>
+<DoDontRow>
 
-<Column colMd={4} colLg={4}>
-
-<DoDontExample type="do" caption="Do make sure the anchor point lands clearly on intersecting grid lines.">
+<DoDont caption="Do make sure the anchor point lands clearly on intersecting grid lines.">
 
 ![Circle with anchor points on the grid intersections](./images/Snapping_Do.svg)
 
-</DoDontExample>
+</DoDont>
 
-</Column>
-
-<Column colMd={4} colLg={4}>
-
-<DoDontExample type="dont" caption="Don’t place anchor points off-grid unless absolutely necessary.">
+<DoDont type="dont" caption="Don’t place anchor points off-grid unless absolutely necessary.">
 
 ![Circle with anchor points off-grid](./images/Snapping_Dont.svg)
 
-</DoDontExample>
+</DoDont>
 
-</Column>
-
-</Row>
+</DoDontRow>
 
 ## Drawing
 
@@ -219,29 +211,18 @@ Create curves using the grid as your guide and use quarter circles, semicircles 
 
 </Row>
 
-<Row className="mock-gallery">
-
-<Column colMd={4} colLg={4}>
-
-<DoDontExample type="do" caption="Do use clear and regular curves when possible.">
+<DoDontRow>
+<DoDont caption="Do use clear and regular curves when possible.">
 
 ![Curves made from sections of cirlces](./images/CircularCurves_Do.svg)
 
-</DoDontExample>
-
-</Column>
-
-<Column colMd={4} colLg={4}>
-
-<DoDontExample type="dont" caption="Don't use irregular curves if they can be avoided.">
+</DoDont>
+<DoDont type="dont" caption="Don't use irregular curves if they can be avoided.">
 
 ![Curves made without circles](./images/CircularCurves_Dont.svg)
 
-</DoDontExample>
-
-</Column>
-
-</Row>
+</DoDont>
+</DoDontRow>
 
 ### Organic Curves
 
@@ -263,25 +244,18 @@ Organic Bézier curves may be used to add more realism and character to your ill
 
 </Row>
 
-<Row className="mock-gallery">
-
-<Column colMd={4} colLg={4}>
-<DoDontExample type="do" caption="Always use isometric angles as the foundation when drawing organic curves.">
+<DoDontRow>
+<DoDont caption="Always use isometric angles as the foundation when drawing organic curves.">
 
 ![Shoulders aligned to isometric angles](./images/OrganicCurves_Do.svg)
 
-</DoDontExample>
-</Column>
-
-<Column colMd={4} colLg={4}>
-<DoDontExample type="dont" caption="Don't use non-isometric angles for primary elements that should align to the grid.">
+</DoDont>
+<DoDont type="dont" caption="Don't use non-isometric angles for primary elements that should align to the grid.">
 
 ![Shoulders not aligned to isometric angles](./images/OrganicCurves_Dont.svg)
 
-</DoDontExample>
-</Column>
-
-</Row>
+</DoDont>
+</DoDontRow>
 
 ### Rounded corners and nesting
 
@@ -294,25 +268,18 @@ You can round the corners of angles in Adobe Illustrator for a fluid and control
 
 </ArtDirection>
 
-<Row className="mock-gallery">
-
-<Column colMd={4} colLg={4}>
-<DoDontExample type="do" caption="Nested lines that curve should remain equally spaced with increasing radii.">
+<DoDontRow>
+<DoDont caption="Nested lines that curve should remain equally spaced with increasing radii.">
 
 ![Rounded corners nested with increasing radii](./images/RoundedCorners_Do.svg)
 
-</DoDontExample>
-</Column>
-
-<Column colMd={4} colLg={4}>
-<DoDontExample type="dont" caption="Avoid the use of different corner radii in a nested design.">
+</DoDont>
+<DoDont type="dont" caption="Avoid the use of different corner radii in a nested design.">
 
 ![Rounded corners nested with equal radii](./images/RoundedCorners_Dont.svg)
 
-</DoDontExample>
-</Column>
-
-</Row>
+</DoDont>
+</DoDontRow>
 
 ## Color
 
@@ -382,25 +349,18 @@ The key to lighting within the isometric style is consistency. Keep the directio
 
 </Row>
 
-<Row className="mock-gallery">
-
-<Column colMd={4} colLg={4}>
-<DoDontExample type="do" caption="Use a single light source throughout an illustration.">
+<DoDontRow>
+<DoDont caption="Use a single light source throughout an illustration.">
 
 ![Consistent shadow angles](./images/LightSource_Do.svg)
 
-</DoDontExample>
-</Column>
-
-<Column colMd={4} colLg={4}>
-<DoDontExample type="dont" caption="Don’t imply multiple light sources by using various shadow angles.">
+</DoDont>
+<DoDont type="dont" caption="Don’t imply multiple light sources by using various shadow angles.">
 
 ![Multiple shadow angles](./images/LightSource_Dont.svg)
 
-</DoDontExample>
-</Column>
-
-</Row>
+</DoDont>
+</DoDontRow>
 
 ### Shadow types
 
@@ -413,25 +373,18 @@ There are multiple shadow types to choose from, flat shadows have sharp edges, w
 
 </ArtDirection>
 
-<Row className="mock-gallery">
-
-<Column colMd={4} colLg={4}>
-<DoDontExample type="do" caption="Use consistent shadow styles throughout an illustration.">
+<DoDontRow>
+<DoDont caption="Use consistent shadow styles throughout an illustration.">
 
 ![Consistent shadow types](./images/ShadowType_Do.svg)
 
-</DoDontExample>
-</Column>
-
-<Column colMd={4} colLg={4}>
-<DoDontExample type="dont" caption="Avoid the use of different corner radii in a nested design.">
+</DoDont>
+<DoDont type="dont" caption="Avoid the use of different corner radii in a nested design.">
 
 ![Multiple shadow types](./images/ShadowType_Dont.svg)
 
-</DoDontExample>
-</Column>
-
-</Row>
+</DoDont>
+</DoDontRow>
 
 ### Illumination
 


### PR DESCRIPTION
Closes #539 

**Changed**

- Uses correct `DoDont` component for spacing


