### PR TITLE
fix: tweak pallete space closes #608

### DIFF
--- a/src/components/SwatchPaletteWidget/_swatch-palette-widget.scss
+++ b/src/components/SwatchPaletteWidget/_swatch-palette-widget.scss
@@ -4,11 +4,12 @@
 
   .#{$prefix}--swatch-palette {
     width: 100%;
-    margin-bottom: $spacing-07;
+    margin-bottom: 1px;
 
     .#{$prefix}--swatch {
       padding: $spacing-05;
-      @include carbon--type-style('code-02') .#{$prefix}--swatch-name {
+      @include carbon--type-style('code-02');
+      .#{$prefix}--swatch-name {
         text-transform: capitalize;
       }
       .#{$prefix}--swatch-value {

--- a/src/pages/help/faq.mdx
+++ b/src/pages/help/faq.mdx
@@ -1,11 +1,17 @@
 ---
 title: FAQ
-description: The following are some of the most frequently asked questions about the IBM Design Language. Please check back often, as new FAQs will be added to this list.
+description:
+  The following are some of the most frequently asked questions about the IBM
+  Design Language. Please check back often, as new FAQs will be added to this
+  list.
 ---
 
 <PageDescription>
 
-The IBM brand system is how we express with clarity the value of our products, our people and our company. IBM Design Language provides a comprehensive framework, but we know you might still have questions.
+The IBM brand system is how we express with clarity the value of our products,
+our people and our company. IBM Design Language provides a comprehensive
+framework, but we know you might still have questions.
+
 </PageDescription>
 
 <AnchorLinks>
@@ -16,72 +22,108 @@ The IBM brand system is how we express with clarity the value of our products, o
 
 ## Definitions and strategy
 
-<AccordionGroup>
 <Accordion>
 <AccordionItem title="What’s IBM Design?">
 
-IBM Design represents a globally diverse community of design practitioners and leaders who guide others through the experiences we envision, create and deliver. The design community at IBM is deeply embedded across all key business areas: product, brand, services and operations.
+IBM Design represents a globally diverse community of design practitioners and
+leaders who guide others through the experiences we envision, create and
+deliver. The design community at IBM is deeply embedded across all key business
+areas: product, brand, services and operations.
 
 </AccordionItem>
 
 <AccordionItem title="What’s the IBM Design System (Carbon Design System)?">
-Carbon is our open source design system for digital products, software applications and experiences. With the IBM Design Language as its foundation, the system consists of components, patterns, working code, design tools and resources, human interface guidelines and a vibrant community of contributors.
+  Carbon is our open source design system for digital products, software
+  applications and experiences. With the IBM Design Language as its foundation,
+  the system consists of components, patterns, working code, design tools and
+  resources, human interface guidelines and a vibrant community of contributors.
 </AccordionItem>
 
-
-
 <AccordionItem title="What’s IBM Digital Design?">
-IBM Digital Design is the design practice in IBM for all web experiences that are part of the ibm.com platform. Previously known as Northstar or the v18 design system, IBM Digital Design follows the IBM Design Language and uses Carbon as its core design system. IBM Digital Design is responsible for publishing the web standards as defined by the IBM Design Language, SEO, Privacy, and Accessibility teams at IBM. IBM Digital Design integrates with Carbon to provide the single design system for ibm.com.
+  IBM Digital Design is the design practice in IBM for all web experiences that
+  are part of the ibm.com platform. Previously known as Northstar or the v18
+  design system, IBM Digital Design follows the IBM Design Language and uses
+  Carbon as its core design system. IBM Digital Design is responsible for
+  publishing the web standards as defined by the IBM Design Language, SEO,
+  Privacy, and Accessibility teams at IBM. IBM Digital Design integrates with
+  Carbon to provide the single design system for ibm.com.
 </AccordionItem>
 
 <AccordionItem title="What’s the ibm.com Library?">
-The ibm.com Library is the foundational framework through which IBM Design Language is realized on ibm.com. It consists of components specific to ibm.com, web-optimized Carbon components, layout patterns, code snippets, design kits and usage guidelines.
+  The ibm.com Library is the foundational framework through which IBM Design
+  Language is realized on ibm.com. It consists of components specific to
+  ibm.com, web-optimized Carbon components, layout patterns, code snippets,
+  design kits and usage guidelines.
 </AccordionItem>
 
 <AccordionItem title="How does the IBM Design Language site relate to the IBM Brand Center? ">
-The IBM Brand Center represents the IBM brand definition, architecture and high-level guidance and templates used across the brand worldwide. The IBM Design Language site is the guidance and assets for all the elements used to express the brand in products, communications, marketing, events and all digital experiences.
+  The IBM Brand Center represents the IBM brand definition, architecture and
+  high-level guidance and templates used across the brand worldwide. The IBM
+  Design Language site is the guidance and assets for all the elements used to
+  express the brand in products, communications, marketing, events and all
+  digital experiences.
 </AccordionItem>
 
 <AccordionItem title="What happened to Duo?">
-“Duo” was the code name formerly used for the development of the IBM Design Philosophy and Language.
+  “Duo” was the code name formerly used for the development of the IBM Design
+  Philosophy and Language.
 </AccordionItem>
 
 <AccordionItem title="What’s the business driver behind the creation of IBM Design Language?">
-IBM Design Language was created as a result of the design teams across IBM coming together as one to create a single, common, unifying system. It expresses the IBM brand in a digital system, visual and verbal assets, and actionable guidance. Implementing it creates a stronger, more unified brand presence across the business with greater efficiencies, point of view (POV), curation and instant recognition. The design philosophy informs the IBM Design Language and expresses the POV on design for IBM.
+  IBM Design Language was created as a result of the design teams across IBM
+  coming together as one to create a single, common, unifying system. It
+  expresses the IBM brand in a digital system, visual and verbal assets, and
+  actionable guidance. Implementing it creates a stronger, more unified brand
+  presence across the business with greater efficiencies, point of view (POV),
+  curation and instant recognition. The design philosophy informs the IBM Design
+  Language and expresses the POV on design for IBM.
 </AccordionItem>
 
 </Accordion>
-</AccordionGroup>
 
+## Guidance and contributions
 
-##  Guidance and contributions
-
-<AccordionGroup>
 <Accordion>
 
 <AccordionItem title="Can I contribute to IBM Design Language or the disciplines, for example, Product Design, Digital Design, Event and so on?">
 
-Yes, there are multiple ways to contribute to the IBM Design Language. For the product and digital design disciplines, visit [How to contribute](https://www.carbondesignsystem.com/how-to-contribute/overview) on the Carbon Design System website for further guidance. For contributing to iconography, please visit the GitHub repositories. You can find additional brand system and discipline guidance on [IBM Brand Center](https://www.ibm.com/brand/).
+Yes, there are multiple ways to contribute to the IBM Design Language. For the
+product and digital design disciplines, visit
+[How to contribute](https://www.carbondesignsystem.com/how-to-contribute/overview)
+on the Carbon Design System website for further guidance. For contributing to
+iconography, please visit the GitHub repositories. You can find additional brand
+system and discipline guidance on
+[IBM Brand Center](https://www.ibm.com/brand/).
 
 </AccordionItem>
 
-
 <AccordionItem title="How can my agency access the IBM Design Language guidance?">
 
-All new IBM products and communications need to incorporate the IBM Design Language. If you’re working on a design element for a legacy product, you can access the v1 IBM Design Language site. The IBM Design Language site is available to the public at [www.ibm.com/design/language](https://www.ibm.com/design/language/) and is used to express the IBM brand around the world. Please start using the guidance right away.
+All new IBM products and communications need to incorporate the IBM Design
+Language. If you’re working on a design element for a legacy product, you can
+access the v1 IBM Design Language site. The IBM Design Language site is
+available to the public at
+[www.ibm.com/design/language](https://www.ibm.com/design/language/) and is used
+to express the IBM brand around the world. Please start using the guidance right
+away.
+
 </AccordionItem>
 
 <AccordionItem title="When will more materials be available, for example, to help us create new marketing collateral or design materials for an upcoming event?">
 
-All guidance available for use now is on the IBM Design Language website. New sections are continuously added. Please find out about new materials and planned updates on the [Updates](https://www.ibm.com/design/language/updates/whats-new) or [Roadmap](https://www.ibm.com/design/language/updates/road-map) pages.
+All guidance available for use now is on the IBM Design Language website. New
+sections are continuously added. Please find out about new materials and planned
+updates on the [Updates](https://www.ibm.com/design/language/updates/whats-new)
+or [Roadmap](https://www.ibm.com/design/language/updates/road-map) pages.
+
 </AccordionItem>
 
-
-
 </Accordion>
-</AccordionGroup>
 
 ## Additional questions
 
-If your question hasn’t been answered after browsing the IBM Design Language site, check out our [Support](/help/support) page. If you still have a question, send a message to the IBM Brand Experience Design team directly through the IBM Design Language Slack channel [#ibm-design-language](https://ibm-studios.slack.com/messages/C0U35LB2B).
-
+If your question hasn’t been answered after browsing the IBM Design Language
+site, check out our [Support](/help/support) page. If you still have a question,
+send a message to the IBM Brand Experience Design team directly through the IBM
+Design Language Slack channel
+[#ibm-design-language](https://ibm-studios.slack.com/messages/C0U35LB2B).


### PR DESCRIPTION
@sadekbazaraa @mjabbink one thing to note is that the `1px` space blends in since it invariably comes after the lightest color in the pallete. Not that we'd want to do anything different, it's just difficult to see.