### PR TITLE
Remove Resource card from Illustration: Overview

### DIFF
--- a/src/pages/illustration/overview.mdx
+++ b/src/pages/illustration/overview.mdx
@@ -19,24 +19,6 @@ Our illustrations take on many forms and ultimately have a job to do. They shoul
 
 <Video vimeoId="425895600" />
 
-## Resources
-
-<Row className="resource-card-group">
-<Column colMd={4} colLg={4} noGutterSm>
-    <ResourceCard
-      subTitle="IBM illustration starter kit"
-      aspectRatio="2:1"
-      href="https://github.com/carbon-design-system/carbon/raw/master/packages/pictograms/master/pictogram-master.ai"
-      actionIcon="download"
-      disabled
-      >
-
-![Adobe Illustrator logo](../images/illustrator.png)
-
-  </ResourceCard>
-</Column>
-</Row>
-
 ## Principles
 
 IBM has a distinct perspective on illustration and a carefully crafted set of principles and best practices. Our illustrations aim to be engineered, clear, nimble, diverse and delightful to create the best possible experience for viewers. These principles capture fundamental ideas that are important to the IBM point of view for illustrations and their overall effectiveness regardless of size or medium.


### PR DESCRIPTION
Forgot to remove this card along with the other cards on the Usage tabs.