### PR TITLE
Replace straight quotes with proper apostrophes

### DIFF
--- a/src/pages/color.mdx
+++ b/src/pages/color.mdx
@@ -155,12 +155,12 @@ The color palette has been organized into four distinct 4-Color families, each c
 The following color combinations have been eliminated from the Color families and should be avoided unless required for specific applications, such as Data Visualization.
 
 <DoDontRow>
-<DoDont type="dont" caption="Don't mix greens with reds, magentas or purples.">
+<DoDont type="dont" caption="Don’t mix greens with reds, magentas or purples.">
 
 ![](images/combination-1-wrong.svg)
 
 </DoDont>
-<DoDont type="dont" caption="Don't mix teals with reds or magentas.">
+<DoDont type="dont" caption="Don’t mix teals with reds or magentas.">
 
 ![](images/combination-2-wrong.svg)
 


### PR DESCRIPTION
In “Combinations to avoid” section  — replaced the single straight quote marks with apostrophes in “Do Not” captions

Closes #

{{short description}}

#### Changelog

**New**

- {{new thing}}

**Changed**

- {{change thing}}

**Removed**

- {{removed thing}}
