### PR TITLE
fix: pictogram filtering is broken

### DIFF
--- a/src/components/SVGLibraries/PictogramLibrary/PictogramLibrary.js
+++ b/src/components/SVGLibraries/PictogramLibrary/PictogramLibrary.js
@@ -60,9 +60,11 @@ const IconLibrary = () => {
         const searchValue = searchInputValue.toLowerCase();
         return (
           friendlyName.toLowerCase().includes(searchValue) ||
-          aliases.some((alias) =>
-            alias.toString().toLowerCase().includes(searchValue)
-          ) ||
+          aliases
+            .filter(Boolean)
+            .some((alias) =>
+              alias.toString().toLowerCase().includes(searchValue)
+            ) ||
           category.toLowerCase().includes(searchValue) ||
           name.toLowerCase().includes(searchValue)
         );


### PR DESCRIPTION
We got a null alias from one of the carbon pictograms