### PR TITLE
IDL - Illo Overview - remove anchor

### DIFF
--- a/src/pages/illustration/overview.mdx
+++ b/src/pages/illustration/overview.mdx
@@ -12,7 +12,6 @@ Our illustrations take on many forms and ultimately have a job to do. They shoul
 </PageDescription>
 
 <AnchorLinks>
-  <AnchorLink>Resources</AnchorLink>
   <AnchorLink>Principles</AnchorLink>
   <AnchorLink>Illustration styles</AnchorLink>
 </AnchorLinks>


### PR DESCRIPTION
Removed "Resources" anchor link since there is no resources section anymore.
