### PR TITLE
[IDL] UI icon production guidance update

### DIFF
--- a/src/pages/iconography/ui-icons/contribute.mdx
+++ b/src/pages/iconography/ui-icons/contribute.mdx
@@ -41,7 +41,7 @@ Don’t see the icon you need in the library? Make your own! Follow these guidel
 
 ### Production-ready
 
-To be considered production-ready, all icon submissions must be delivered in SVG format at 16px x 16px for integration with Carbon components, or 32px x 32px for service icons.
+To be considered production-ready, all icon submissions must be delivered in SVG format at 32px x 32px for integration with Carbon components.
 
 - Icons should be at whole pixels. No decimals are allowed in x and y coordinates or width and height fields
 - Each artboard and the artwork within it must be aligned to the pixel grid

--- a/src/pages/iconography/ui-icons/contribute.mdx
+++ b/src/pages/iconography/ui-icons/contribute.mdx
@@ -30,8 +30,8 @@ Don’t see the icon you need in the library? Make your own! Follow these guidel
 
 ## Making an icon
 
-- Create a 16px x 16px or 32px x 32px artboard for each icon.
-- 16 px icons should have 1 px padding. 32 px icons should have 2 px padding.
+- Create a 32px x 32px artboard for each icon.
+- 32px icons should have 2px padding.
 - Set your workspace up from the start to snap to pixels and round values to whole pixels to avoid correcting shapes later.
 - Never use center borders. Centering can cause half pixels.
 - Avoid using the line tool; use the rectangle tool instead. The line tool will place the vector on half pixels.
@@ -50,22 +50,9 @@ To be considered production-ready, all icon submissions must be delivered in SVG
 
 ## Exporting SVGs
 
-### Export SVGs from Sketch
-
-1. Draw a 16px x 16px or 32px x 32 px artboard. 16px icons should have 1px padding. 32px icons should have 2px padding.
-1. Place the icon squarely on the artboard, making sure it’s aligned to the pixel grid.
-1. Convert all strokes to outlines `Shift + ⌘ + O`.
-1. Select any overlapping shapes and click the `Union` icon from the top navigation to merge all of the shapes together.
-1. Make sure the icon is at `#000000` and has no additional styling.
-1. Select the entire artboard, not just the icon.
-1. Click `Make Exportable` at the bottom of the right toolbar in Sketch.
-1. In the `Export` widget select `SVG` in the format dropdown.
-1. Click `Export 'Artboard-Name'`.
-1. Name icon with the `#name--modifier` convention, for example, copy.svg, copy-glyph.svg, add.svg, add-glyph.svg.
-
 ### Export SVGs from Adobe Illustrator
 
-1. Draw a 16px x 16px or 32px x 32 px artboard. 16px icons should have 1px padding. 32px icons should have 2px padding.
+1. Draw a 32px x 32px artboard. 32px icons should have 2px padding.
 1. Place the icon squarely on the artboard, making sure it’s aligned to the pixel grid.
 1. Expand all strokes `Object > Expand`.
 1. Select all overlapping shapes and click the `Unite` icon in the `Pathfinder` panel to merge all of the shapes together.
@@ -87,8 +74,18 @@ To be considered production-ready, all icon submissions must be delivered in SVG
 
 ## Contribution process
 
-Does your icon have potential for other products at IBM? If so, please consider contributing to the design system. IBM welcomes icon contributions in the form of a pull request to our [icons repository](https://github.com/carbon-design-system/carbon/tree/master/packages/icons). If you’re unable to make a pull request, please [submit an issue in the repo](https://github.com/IBM/carbon-icons/issues/new) with the icon attached.
+Does your icon have potential for other products at IBM? If so, please consider contributing to the design system. IBM welcomes icon contributions to our iconography library. You’re welcome to submit a single icon or a batch of icons for approval.
 
-Please note that Carbon contribution is **not required** in order to introduce a new icon into your product’s UI. If your icon is determined to be broadly useful in Carbon and passes IBM Brand design reviews, then it may also be integrated into the design system.
+### Getting started
 
-If your icon submission is accepted, the team will notify you. If changes are needed, you’ll need to create a new contribution issue after reworking it based on feedback from the Design System and Brand teams.
+Before submitting artwork, first review our [icons library](https://www.carbondesignsystem.com/guidelines/icons/library/) or download the [Carbon icon master .ai file](https://github.com/carbon-design-system/carbon/tree/master/packages/icons/master) to check your design for duplication against existing icons.
+
+### Approval process 
+
+Icons for use within IBM must go through a design review process to ensure consistency and proper representation of the IBM brand across all environments. The process begins when you create a GitHub issue. Design review and approval typically take 14–21 days from issue creation, depending on the number of icons contributed.
+
+If your submission is accepted, the team will assign someone to your issue. If changes are needed, the team will note them in the issue and may return your submission with recommendations or suggest reworking the icon based on feedback from the Design System and Brand teams.
+
+Once the submission is approved it will then go through our process to be included into the Adobe Illustrator IBM Icon master file and be made available in the IBM Design Language and Carbon libraries.
+
+Submit icons for approval by creating a [single](https://github.ibm.com/brand/ui-icons/issues/new?assignees=&labels=&template=single-ui-icon-approval.md&title=%5Bui-icon%5D) or [batch](https://github.ibm.com/brand/ui-icons/issues/new?assignees=&labels=&template=batch-ui-icon-approval-request.md&title=%5Bui-icon-batch%5D) GitHub issue for your contribution.


### PR DESCRIPTION
Updating UI icon production and contribution guidance to better reflect our production practices. Will make the same changes to Carbon site UI icon guidance: https://github.com/carbon-design-system/carbon-website/pull/1600

#### Changelog


**Changed**

- updated Contribution section to match updates made to Carbon site

**Removed**

- removed mention of creating 16px icons and exporting from Sketch section 
