### PR TITLE
Fix broken link

### DIFF
--- a/src/pages/2x-grid.mdx
+++ b/src/pages/2x-grid.mdx
@@ -446,9 +446,9 @@ interfaces, please visit
 <Row className="resource-card-group">
 <Column colMd={4} colLg={4} noGutterSm>
     <ResourceCard
-      subTitle="2x Grid in UI: Basics"
+      subTitle="2x Grid in UI: Overview"
       aspectRatio="2:1"
-      href="https://www.carbondesignsystem.com/guidelines/2x-grid/basics"
+      href="https://www.carbondesignsystem.com/guidelines/2x-grid/overview"
       actionIcon="launch"
       >
 


### PR DESCRIPTION
The resource card "2x grid in UI: basics" was broken, the carbon page is now called overview instead of basics.

