### PR TITLE
fix: typetester and typeset style vertical alignment

### DIFF
--- a/src/components/TypeTester/_type-tester.scss
+++ b/src/components/TypeTester/_type-tester.scss
@@ -71,8 +71,6 @@
       .#{$prefix}--list-box__field {
         background: $ui-02;
         height: 3rem;
-        padding-top: $spacing-05;
-        padding-bottom: rem(15px);
         border-bottom: 1px solid $carbon--gray-20;
 
         &:hover {

--- a/src/components/TypesetStyle/_typeset-style.scss
+++ b/src/components/TypesetStyle/_typeset-style.scss
@@ -68,7 +68,7 @@
   z-index: 2;
   box-sizing: content-box;
   position: sticky;
-  top: 112px;
+  top: 120px;
 }
 
 .#{$prefix}--typeset-style-nav-shiv {
@@ -85,7 +85,6 @@
   padding-left: $spacing-05;
   padding-right: 0;
   width: 100%;
-  margin-top: 8px;
 
   @include carbon--breakpoint('md') {
     width: 62.5%;


### PR DESCRIPTION
Closes #755 

Compare to current positioning: 

1. `/typography/typeface`

<img width="817" alt="Screen Shot 2020-10-02 at 2 45 47 PM" src="https://user-images.githubusercontent.com/32556167/94972486-f9768400-04ce-11eb-9fff-3f6d210e4d1f.png">

2. `/typography/type-specs-ui`

<img width="1048" alt="Screen Shot 2020-10-02 at 2 45 59 PM" src="https://user-images.githubusercontent.com/32556167/94972482-f7acc080-04ce-11eb-9ff4-b1a0bacab4cc.png">