### PR TITLE
[IDL] Update left nav link to carbon libraries

### DIFF
--- a/src/gatsby-theme-carbon/components/LeftNav/ResourceLinks.js
+++ b/src/gatsby-theme-carbon/components/LeftNav/ResourceLinks.js
@@ -8,7 +8,7 @@ const links = [
   },
   {
     title: 'Carbon libraries',
-    href: 'https://www.carbondesignsystem.com/resources/#theme-libraries',
+    href: 'https://www.carbondesignsystem.com/designing/kits/sketch',
   },
 ];
 


### PR DESCRIPTION
Update the resource link in the left nav for "Carbon libraries" from the current "https://www.carbondesignsystem.com/resources/#theme-libraries"  to the correct: :"https://www.carbondesignsystem.com/designing/kits/sketch"