### PR TITLE
Fix/sass mixin bug by replacing with rem values, closes #795

### DIFF
--- a/src/components/Carousel/_carousel.scss
+++ b/src/components/Carousel/_carousel.scss
@@ -84,5 +84,5 @@
 }
 
 .#{$prefix}--carousel-nav-item {
-  width: rem(16px);
+  width: 1rem;
 }

--- a/src/components/ColorBlock/color-block.scss
+++ b/src/components/ColorBlock/color-block.scss
@@ -7,17 +7,17 @@
   position: relative;
   display: block;
   margin-top: $spacing-01;
-  height: rem(14px);
-  width: rem(14px);
-  border-radius: rem(14px);
+  height: 0.875rem;
+  width: 0.875rem;
+  border-radius: 0.875rem;
 
   // needed to fix anti-aliasing issue in firefox
   &:before {
     position: absolute;
     content: '';
-    height: rem(14px);
-    width: rem(14px);
-    border-radius: rem(14px);
+    height: 0.875rem;
+    width: 0.875rem;
+    border-radius: 0.875rem;
     border: 1px solid $ui-03;
     left: -1px;
     top: -1px;

--- a/src/components/HomepageVideo/_homepage-video.scss
+++ b/src/components/HomepageVideo/_homepage-video.scss
@@ -130,7 +130,7 @@
 
 .#{$prefix}--homepage-video-cta-icon {
   fill: $carbon--white-0;
-  width: rem(20px);
-  height: rem(20px);
+  width: 1.25rem;
+  height: 1.25rem;
   transition: fill $transition--base $carbon--standard-easing;
 }

--- a/src/components/NonLatinScripts/_non-latin-script.scss
+++ b/src/components/NonLatinScripts/_non-latin-script.scss
@@ -5,8 +5,8 @@
   color: $carbon--white-0;
   background-color: $carbon--purple-60;
   text-align: center;
-  width: rem(50px);
-  height: rem(50px);
+  width: 3.125rem;
+  height: 3.125rem;
   position: absolute;
   right: 0;
   top: 1rem;

--- a/src/components/TypeFaceSubFamilies/_typeface-sub-families.scss
+++ b/src/components/TypeFaceSubFamilies/_typeface-sub-families.scss
@@ -1,6 +1,6 @@
 .#{$prefix}--subfamilies-menu-tabs {
   padding-left: 0 !important;
-  width: rem(10px);
+  width: 0.625rem;
 }
 
 .#{$prefix}--hide {

--- a/src/components/TypeTester/_type-tester.scss
+++ b/src/components/TypeTester/_type-tester.scss
@@ -102,7 +102,7 @@
 
           .#{$prefix}--list-box__menu-item__option {
             height: auto;
-            padding: rem(14px) 0;
+            padding: 0.875rem 0;
           }
         }
       }

--- a/src/components/TypesetExample/_typeset-example.scss
+++ b/src/components/TypesetExample/_typeset-example.scss
@@ -8,7 +8,7 @@
 
 .#{$prefix}--typeset-example-row {
   background-color: $carbon--white-0;
-  min-height: rem(216px);
+  min-height: 13.5rem;
 }
 
 .#{$prefix}--typeset-example-group-title {

--- a/src/components/TypesetStyle/_typeset-style.scss
+++ b/src/components/TypesetStyle/_typeset-style.scss
@@ -151,7 +151,7 @@
 
 .#{$prefix}--typeset-style-input {
   margin: 0;
-  margin-right: rem(20px);
+  margin-right: 1.25rem;
   width: 100%;
 }
 

--- a/src/styles/_homepage.scss
+++ b/src/styles/_homepage.scss
@@ -1,10 +1,10 @@
 .homepage-tiles--end {
   margin-bottom: 10rem;
-  margin-top: rem(1px);
+  margin-top: 0.0625rem;
 }
 
 .homepage-row {
-  margin-top: rem(80px);
+  margin-top: 5rem;
   --space: 0;
 }
 

--- a/src/styles/_images.scss
+++ b/src/styles/_images.scss
@@ -28,12 +28,12 @@ img[src$='svg'] {
 .gallery-row-padding {
   margin-top: 0;
   @include carbon--breakpoint('md') {
-    margin-top: rem(32px);
+    margin-top: 2rem;
   }
 }
 
 .gallery-row-padding div {
-  margin-top: rem(24px);
+  margin-top: 1.5rem;
   @include carbon--breakpoint('md') {
     margin-top: 0;
   }

--- a/src/styles/_typography.scss
+++ b/src/styles/_typography.scss
@@ -65,7 +65,7 @@ $type-scale: 0.75rem, 0.875rem, 1rem, 1.125rem, 1.25rem, 1.5rem, 1.75rem, 2rem,
 .type-scale-table {
   overflow-x: auto;
   background: $ui-02;
-  border-bottom: rem(1px) solid $ui-03;
+  border-bottom: 0.0625rem solid $ui-03;
 
   table tbody tr {
     border: none;
@@ -93,7 +93,7 @@ $type-scale: 0.75rem, 0.875rem, 1rem, 1.125rem, 1.25rem, 1.5rem, 1.75rem, 2rem,
     padding: 0 $spacing-09 0 0;
 
     @include carbon--breakpoint('md') {
-      padding-right: rem(112px);
+      padding-right: 7rem;
     }
 
     @include carbon--breakpoint('lg') {
@@ -139,7 +139,7 @@ $type-scale: 0.75rem, 0.875rem, 1rem, 1.125rem, 1.25rem, 1.5rem, 1.75rem, 2rem,
   }
 
   table tbody tr:nth-child(7) td:first-child {
-    padding-bottom: rem(26px);
+    padding-bottom: 1.625rem;
   }
 
   table tbody tr:nth-child(8) td:first-child {
@@ -155,24 +155,24 @@ $type-scale: 0.75rem, 0.875rem, 1rem, 1.125rem, 1.25rem, 1.5rem, 1.75rem, 2rem,
   }
 
   table tbody tr:nth-child(11) td:first-child {
-    padding-bottom: rem(56px);
+    padding-bottom: 35rem;
   }
 
   table tbody tr:nth-child(12) td:first-child,
   table tbody tr:nth-child(13) td:first-child {
-    padding-bottom: rem(64px);
+    padding-bottom: 4rem;
   }
 
   table tbody tr:nth-child(14) td:first-child {
-    padding-bottom: rem(72px);
+    padding-bottom: 4.5rem;
   }
 
   table tbody tr:nth-child(15) td:first-child {
-    padding-bottom: rem(80px);
+    padding-bottom: 5rem;
   }
 
   table tbody tr:nth-child(16) td:first-child {
-    padding-bottom: rem(88px);
+    padding-bottom: 5.5rem;
   }
 
   table tbody tr:nth-child(17) td:nth-child(2) {

--- a/src/styles/_typography.scss
+++ b/src/styles/_typography.scss
@@ -155,7 +155,7 @@ $type-scale: 0.75rem, 0.875rem, 1rem, 1.125rem, 1.25rem, 1.5rem, 1.75rem, 2rem,
   }
 
   table tbody tr:nth-child(11) td:first-child {
-    padding-bottom: 35rem;
+    padding-bottom: 3.5rem;
   }
 
   table tbody tr:nth-child(12) td:first-child,


### PR DESCRIPTION
Closes #795

In some `.scss` files, a `rem(<pixel value>)` has been used to calculate values in rem units. However, there is no internal Sass mixin called `rem()`, nor is there an external library as a dependency that uses this notation. Therefore all of the values expressed with `rem()` are causing an error in the browser.

#### Changelog

**Changed**

- all `rem()` notations to actual rem values

Some before and after screenshots:

##### Typeset example row before and after
<img width="1898" alt="typeset-example-row with buggy value" src="https://user-images.githubusercontent.com/1133238/95905268-4c8ae980-0da1-11eb-96a3-ba24122a7cb9.png">

<img width="1844" alt="typeset-example-row with correct value" src="https://user-images.githubusercontent.com/1133238/95905346-69272180-0da1-11eb-9cbd-cbde1d6de7c3.png">

##### Type scale table before and after

<img width="956" alt="type-scale-table with buggy values" src="https://user-images.githubusercontent.com/1133238/95905435-84922c80-0da1-11eb-8c6d-38502a77194c.png">

<img width="772" alt="type-scale-table with correct value" src="https://user-images.githubusercontent.com/1133238/95905446-8956e080-0da1-11eb-959e-59ce47a1f7d8.png">
