### PR TITLE
fix: changed the direction and alignment of the tooltips

### DIFF
--- a/src/components/SVGLibraries/shared/ActionBar.js
+++ b/src/components/SVGLibraries/shared/ActionBar.js
@@ -59,8 +59,8 @@ const ActionBar = ({
       <TooltipDefinition
         onFocus={() => setIsActionBarVisible(true)}
         onClick={handleDownload}
-        align="center"
         direction="top"
+        align="end"
         tooltipText="Download SVG"
         className={styles.tooltip}
         triggerClassName={styles.trigger}>
@@ -68,8 +68,8 @@ const ActionBar = ({
       </TooltipDefinition>
       {shouldShowCopyButton && (
         <TooltipDefinition
-          align="center"
           direction="top"
+          align="end"
           tooltipText={copyText}
           onClick={handleCopy}
           onFocus={() => setIsActionBarVisible(true)}


### PR DESCRIPTION
Closes [#1068](https://github.com/carbon-design-system/gatsby-theme-carbon/issues/1068) for IDL.

In the issue Mike asks for the right-most column to have the tooltip set to `direction="left"` and `align="end"`. Rather than mess with refactoring that component (💰 ) for just the right column on the different screen-sizes, I opt-ed to just set the tooltips to `direction="top"` and `align="end"`. Applies the styling to all the SvgCards instead of just the right-most column. I think it looks pretty sharp. Thoughts?

current:
![image](https://user-images.githubusercontent.com/15822070/107569609-22f69900-6bae-11eb-8138-835dddb0bbe7.png)

new:
![image](https://user-images.githubusercontent.com/15822070/107569640-2c800100-6bae-11eb-9252-fa870f14413e.png)
