### PR TITLE
(fix) broken link for color files

### DIFF
--- a/src/pages/color.mdx
+++ b/src/pages/color.mdx
@@ -46,7 +46,7 @@ with nature, yet chosen for their luminous quality in the digital world.
     <ResourceCard
       subTitle="IBM color palette (.ase and .clr)"
       aspectRatio="2:1"
-      href="https://github.com/carbon-design-system/carbon/raw/master/packages/colors/artifacts/IBM_Colors.zip"
+      href="https://github.com/carbon-design-system/carbon/raw/main/packages/colors/artifacts/IBM_Colors.zip"
       actionIcon="download"
       >
 


### PR DESCRIPTION
**Changed**
- The `IBM color palette` resource card link was broken. I updated it so it will download and open the correct ZIP with the v02.1 color files.

-----

**Testing**
- Make sure you can download and open the zip file from the `IBM color palette` resource card.
- `Color page` -> `Resources section` -> `IBM color palette` resource card
