### PR TITLE
fix: black outline from the swatch palette + fix missing images

### DIFF
--- a/src/components/SwatchPaletteWidget/_swatch-palette-widget.scss
+++ b/src/components/SwatchPaletteWidget/_swatch-palette-widget.scss
@@ -66,6 +66,7 @@
     padding: $spacing-03 $spacing-05;
     outline: none;
     transition: background-color 100ms cubic-bezier(0.2, 0.2, 0.38, 0.9);
+    border: none;
 
     &:not(:last-of-type)::after {
       height: 100%;

--- a/src/styles/Grid.module.scss
+++ b/src/styles/Grid.module.scss
@@ -2,6 +2,10 @@
   @include carbon--breakpoint-down('md') {
     padding-right: 0px;
   }
+
+  a {
+    display: block;
+  }
 }
 
 // gallery clusters


### PR DESCRIPTION
This PR fixes black outline from the swatch palette widget #920 and issue with images not being rendered properly on the What's new page #935 .

Closes #935,  closes #920