### PR TITLE
Update link for Sketch library on Pictograms page

### DIFF
--- a/src/pages/iconography/pictograms/design.mdx
+++ b/src/pages/iconography/pictograms/design.mdx
@@ -35,7 +35,7 @@ typeface and work well in presentations and marketing communications.
 <Column colMd={4} colLg={4} noGutterSm>
     <ResourceCard
       subTitle="IBM Design Language library"
-      href="sketch://add-library/cloud/nwqmk"
+      href="sketch://add-library/cloud/4f1cbe6c-6626-405e-8c46-a9ae41a30cba"
       >
 
 ![Sketch icon](../../../images/resource-cards/sketch.png)


### PR DESCRIPTION
Current link doesn't work, most likely because Sketch phased out short links some time ago. Updated it to point to IBM Design Language V2 library.