### PR TITLE
Removed resource card for Noto Japanese

### DIFF
--- a/src/pages/typography/typeface.mdx
+++ b/src/pages/typography/typeface.mdx
@@ -230,17 +230,7 @@ Chinese is scheduled for release in 2022–2023 and will support both Traditiona
 
   </ResourceCard>
 </Column>
-<Column colMd={4} colLg={4} noGutterSm>
-    <ResourceCard
-      subTitle={<>Japanese<br />Noto Sans JP</>}
-      aspectRatio="2:1"
-      href="https://fonts.google.com/specimen/Noto+Sans+JP"
-      >
 
-![google fonts logo](../../images/resource-cards/google-fonts.png)
-
-  </ResourceCard>
-</Column>
 </Row>
 
 ## Open source licenses


### PR DESCRIPTION
Removed resource card for Noto Japanese here: https://www.ibm.com/design/language/typography/typeface#asian-scripts

Closes #

{{short description}}

#### Changelog

**New**

- {{new thing}}

**Changed**

- {{change thing}}

**Removed**

- {{removed thing}}
