### PR TITLE
Changed versus to vs.

### DIFF
--- a/src/pages/typography/typeface.mdx
+++ b/src/pages/typography/typeface.mdx
@@ -205,7 +205,7 @@ non-Latin are shown below with what’s also in the pipeline.
 
 ### Asian scripts
 
-Chinese is scheduled for release in 2022–2023 and will support both Traditional and Simplified Chinese. The Chinese scripts are currently under development. In the meantime, we have chosen some open-source, Chinese typefaces that can work well with the IBM Plex Family.
+Chinese is scheduled for release in 2022–2023 and will support both Traditional and Simplified Chinese. The Chinese scripts are currently under development. In the meantime, we have chosen some open source, Chinese typefaces that can work well with the IBM Plex Family.
 
 <Row className="resource-card-group">
 <Column colMd={4} colLg={4} noGutterSm>


### PR DESCRIPTION
Removed hyphen in open-source. We don’t use the hyphen anywhere when we mention open source. Even on this page in header underneath or on the About Carbon pages.

Closes #

{{short description}}

#### Changelog

**New**

- {{new thing}}

**Changed**

- {{change thing}}

**Removed**

- {{removed thing}}
