### PR TITLE
Added “Japanese” to the Language support list

### DIFF
--- a/src/pages/typography/typeface.mdx
+++ b/src/pages/typography/typeface.mdx
@@ -167,7 +167,7 @@ Estonian<br />Faroese<br />Filipino<br />Finnish
 
 French<br />Galician<br />Ganda<br />German<br />Gilaki<br />Greek<br />Gujari<br />Gusii<br />Hausa<br />Hawaiian<br />
 Hazaragi<br />Hebrew<br />Hindko<br />Hungarian<br />Icelandic<br />Indonesian<br />Indus<br />Ingush<br />
-Irish<br />Italian<br />Jola-Fonyi<br />Kabuverdianu<br />Kachi
+Irish<br />Italian<br />Japanese<br />Jola-Fonyi<br />Kabuverdianu<br />Kachi
 Koli<br />Kalaallisut<br />Kalenjin<br />Kamba<br />
 Kanuri<br />Kashmiri<br />Kazakh<br />Khowar<br />Kikuyu<br />Kinyarwanda<br />Kohistani<br />Korean<br />Kurdish<br />Kuy<br />Kyrgyz<br />Lahnda<br />Laki<br />
 Latvian<br />Lithuanian<br />Luhya


### PR DESCRIPTION
Second column https://www.ibm.com/design/language/typography/typeface#language-support

Closes #

{{short description}}

#### Changelog

**New**

- {{new thing}}

**Changed**

- {{change thing}}

**Removed**

- {{removed thing}}
