### PR TITLE
fix: changed broken sketch links for idl library

### DIFF
--- a/src/gatsby-theme-carbon/components/LeftNav/ResourceLinks.js
+++ b/src/gatsby-theme-carbon/components/LeftNav/ResourceLinks.js
@@ -7,7 +7,7 @@ const links = [
     href: 'sketch://add-library/cloud/4f1cbe6c-6626-405e-8c46-a9ae41a30cba',
   },
   {
-    title: 'Carbon libraries',
+    title: 'Carbon Sketch libraries',
     href: 'https://www.carbondesignsystem.com/designing/kits/sketch',
   },
 ];

--- a/src/gatsby-theme-carbon/components/LeftNav/ResourceLinks.js
+++ b/src/gatsby-theme-carbon/components/LeftNav/ResourceLinks.js
@@ -3,7 +3,7 @@ import ResourceLinks from 'gatsby-theme-carbon/src/components/LeftNav/ResourceLi
 
 const links = [
   {
-    title: 'IDL library',
+    title: 'IDL Sketch library',
     href: 'sketch://add-library/cloud/4f1cbe6c-6626-405e-8c46-a9ae41a30cba',
   },
   {

--- a/src/gatsby-theme-carbon/components/LeftNav/ResourceLinks.js
+++ b/src/gatsby-theme-carbon/components/LeftNav/ResourceLinks.js
@@ -4,7 +4,7 @@ import ResourceLinks from 'gatsby-theme-carbon/src/components/LeftNav/ResourceLi
 const links = [
   {
     title: 'IDL library',
-    href: 'sketch://add-library/cloud/nwqmk',
+    href: 'sketch://add-library/cloud/4f1cbe6c-6626-405e-8c46-a9ae41a30cba',
   },
   {
     title: 'Carbon libraries',

--- a/src/pages/iconography/pictograms/contribute.mdx
+++ b/src/pages/iconography/pictograms/contribute.mdx
@@ -21,7 +21,7 @@ As IBM continues to innovate with products and services, you may find the need f
 
 Don’t see the pictogram you need in the library? Make your own! Follow these guidelines to ensure visual consistency and proper formatting.
 
-- All pictograms should be unique and not redundant with any existing pictograms in the system. Look through the pictograms in the [IBM Design Sketch kit](sketch://add-library/cloud/nwqmk) to ensure that your proposed new pictogram is not already represented.
+- All pictograms should be unique and not redundant with any existing pictograms in the system. Look through the pictograms in the [IBM Design Sketch kit](sketch://add-library/cloud/4f1cbe6c-6626-405e-8c46-a9ae41a30cba) to ensure that your proposed new pictogram is not already represented.
 - All pictograms should adhere to the [IBM Design Language visual style](/iconography/pictograms/design).
 - All pictograms should comply with IBM [accessibility standards](https://www.carbondesignsystem.com/guidelines/accessibility/overview).
 - All pictograms should be usable across all supported platforms and devices.

--- a/src/pages/typography/type-specs-ui.mdx
+++ b/src/pages/typography/type-specs-ui.mdx
@@ -47,7 +47,7 @@ scales, styles and alignment on screens.
   <ResourceCard
     subTitle="IBM Design Language library"
     aspectRatio="2:1"         
-    href="sketch://add-library/cloud/nwqmk"
+    href="sketch://add-library/cloud/4f1cbe6c-6626-405e-8c46-a9ae41a30cba"
     >
 
 ![sketch icon](../../images/resource-cards/sketch.png)


### PR DESCRIPTION
Closes [Brand Issue #5](https://github.com/ibm-brand/design-language/issues/5)

Broken links fix for IDL Library sketch workspace.

#### Changelog

**Changed**

- Correct IDL Library links on:

  - left nav-bar link
  - typography/type-specs-ui#resources
  - color#resources

**Removed**

- Broken links
