### PR TITLE
fix: update top positioning for filter in app icons tab

### DIFF
--- a/src/components/SVGLibraries/AppIconLibrary/AppIconLibrary.module.scss
+++ b/src/components/SVGLibraries/AppIconLibrary/AppIconLibrary.module.scss
@@ -76,7 +76,7 @@
   grid-gap: 1px;
   position: sticky;
   z-index: z('dropdown');
-  top: 7rem;
+  top: 6.95rem;
   transition: box-shadow $duration--fast-02 ease;
   @include carbon--breakpoint-down('md') {
     grid-template-columns: 1fr 1fr;


### PR DESCRIPTION
Closes #1009

Updates app icon filter row positioning

#### Changelog

**Changed**

- changing position `top: 7rem` to `top: 6.95rem` to acconut for the pixel difference.

Make sure the tabs look good
