### PR TITLE
Fix/resource icon size

### DIFF
--- a/src/pages/data-visualization/design/basics.mdx
+++ b/src/pages/data-visualization/design/basics.mdx
@@ -39,8 +39,7 @@ href="https://www.sketch.com/s/1a36060a-7a5d-4ddb-aab1-639caa1f74d4"
 actionIcon="download"
 >
 
-
-![Sketch Icon](../../../images/resource-cards/sketch.svg)
+<img src="../../../images/resource-cards/sketch.svg" alt="Sketch Icon" style="width: inherit" />
 
 </ResourceCard>
 </Column>


### PR DESCRIPTION
Closes [none]

Fixed Sketch icon size on a resource card (image at the bottom of the Pull Request.)

#### Changelog

**New**

- N/A

**Changed**

- Style on the `img` for the Sketch file on a resource card in the `/data-visualization/design/basics/` page

**Removed**

- N/A

#### Example Image

![image](https://user-images.githubusercontent.com/83667344/142023775-bc54f26a-f60f-427d-877d-11dd903799d4.png)