### PR TITLE
fix(design): remove ibm--z and ibm--z--partition from website index

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -20,7 +20,17 @@ exports.onPreBootstrap = async ({ reporter }) => {
   reporter.log(`Processing SVG metadata`);
 
   const essentialIconData = iconData.map(removeUnusedData);
-  const essentialPictogramData = pictogramData.map(removeUnusedData);
+  const essentialPictogramData = pictogramData
+    .map(removeUnusedData)
+    .filter((pictogram) => {
+      if (
+        pictogram.name === 'ibm--z' ||
+        pictogram.name === 'ibm--z--partition'
+      ) {
+        return false;
+      }
+      return true;
+    });
 
   fs.writeFileSync(
     path.join(outDir, 'IconLibrary/metadata.json'),

--- a/yarn.lock
+++ b/yarn.lock
@@ -1133,7 +1133,7 @@
     "@carbon/import-once" "^10.6.0"
     "@carbon/layout" "^10.35.0"
 
-"@carbon/icon-helpers@^10.27.0", "@carbon/icon-helpers@^10.28.0":
+"@carbon/icon-helpers@^10.28.0":
   version "10.28.0"
   resolved "https://registry.yarnpkg.com/@carbon/icon-helpers/-/icon-helpers-10.28.0.tgz#702f1bb055c6c2bc203cdd44582ebd3d2801eaaf"
   integrity sha512-hf4fjouzr3jCvh5lTWJt87ABWmoq+3ck0/OOLpxUZLfhumTLRW+8H1Ctz0ldQh5mhmFaPNQUifll6tGI5bkmTw==


### PR DESCRIPTION
Verify that `ibm--z` and `ibm--z--partition` do not show up in the pictogram index. 

Relevant slack convo: 
https://ibm-studios.slack.com/archives/GCQ5R263T/p1646931614070099