### PR TITLE
Fix: Changed file path for broken zip resource card

### DIFF
--- a/src/pages/illustration/people/index.mdx
+++ b/src/pages/illustration/people/index.mdx
@@ -320,7 +320,7 @@ Our palette is engineered by blending red and green to create two general huesâ€
     <ResourceCard
       subTitle="People palette (.ase and .clr)"
       aspectRatio="2:1"
-      href="../../../../static/files/IBM_People-Palette.zip"
+      href="/files/IBM_People-Palette.zip"
       actionIcon="download"
       >
 


### PR DESCRIPTION
Closes #1092

Fixes the file path from the resource card at the bottom of the page

#### Changelog

**Changed**

- Corrected the file path for zip download