### PR TITLE
fix: typo on infogram page description

### DIFF
--- a/src/pages/infographics/infograms/index.mdx
+++ b/src/pages/infographics/infograms/index.mdx
@@ -8,7 +8,7 @@ import OverviewCard from "../../../components/OverviewCard";
 
 <PageDescription>
 
-Infograms are information graphics in the style of IBM pictograms. Unlike the charts found in the IBM pictogram library, which are used to illustrate the idea of data visualization, infograms are depictions of real data. The infogram is adapted for small spaces, works well as tertiary or maginal data, and stylistically pairs with productive pictograms in visual harmony.
+Infograms are information graphics in the style of IBM pictograms. Unlike the charts found in the IBM pictogram library, which are used to illustrate the idea of data visualization, infograms are depictions of real data. The infogram is adapted for small spaces, works well as tertiary or marginal data, and stylistically pairs with productive pictograms in visual harmony.
 
 </PageDescription>
 


### PR DESCRIPTION
Closes [Brand Center #10](https://github.com/ibm-brand/design-language/issues/10)

Just a little typo correction on the Infograms page

#### Changelog

**Changed**

- "maginal" to "marginal" in the Infograms page description
