### PR TITLE
chore(deploy-previews): introduce deploy previews

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,3 +1,7 @@
+require('dotenv').config();
+
+const { PATH_PREFIX = '/design/language' } = process.env;
+
 module.exports = {
   siteMetadata: {
     title: 'IBM Design Language',
@@ -6,7 +10,7 @@ module.exports = {
     description:
       'The IBM Design Language provides the guidance and assets used to express the IBM brand in products, communications, marketing, events and digital experiences.',
   },
-  pathPrefix: '/design/language',
+  pathPrefix: PATH_PREFIX,
   plugins: [
     {
       resolve: 'gatsby-theme-carbon',

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "@babel/core": "^7.14.6",
     "babel-eslint": "^10.1.0",
     "carbon-icons": "^7.0.7",
+    "dotenv": "^16.0.1",
     "eslint": "^7.4.0",
     "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-import": "^2.16.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5722,6 +5722,11 @@ dot-prop@^5.2.0:
   dependencies:
     is-obj "^2.0.0"
 
+dotenv@^16.0.1:
+  version "16.0.1"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.0.1.tgz#8f8f9d94876c35dac989876a5d3a82a267fdce1d"
+  integrity sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ==
+
 dotenv@^8.2.0:
   version "8.6.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.6.0.tgz#061af664d19f7f4d8fc6e4ff9b584ce237adcb8b"
@@ -10678,7 +10683,7 @@ minimatch@3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimatch@^3.0.4, minimatch@^3.1.1:
+minimatch@^3.0.4:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==


### PR DESCRIPTION
This PR is an update in support of deploy previews on Jenkins. It is necessary to be able to set the `PATH_PREFIX` via environment variable as the path changes based on the deploy preview folder.

#### Changelog

**Changed**

- Add `dotenv` dependency
- Add `PATH_PREFIX` environment variable in gatsby config
