### PR TITLE
Update app-icons.yaml

### DIFF
--- a/src/data/app-icons.yaml
+++ b/src/data/app-icons.yaml
@@ -5799,7 +5799,7 @@
     - code
     - console
 - name: Security-026
-  friendly_name: Unassigned Security
+  friendly_name: Unassigned
   category: Stroke style
   aliases:
     - Blue


### PR DESCRIPTION
fix naming on one icon, Security-026 from "Unassigned Security" to "Unassigned"
