### PR TITLE
fix: changed file path from relative to absolute due to 404

### DIFF
--- a/src/pages/ibm-logos/8-bar.mdx
+++ b/src/pages/ibm-logos/8-bar.mdx
@@ -499,7 +499,7 @@ liability and so on. IBM requires all third parties to comply with these guideli
     <ResourceCard
       actionIcon="download"
       subTitle={"IBM logo and brand guidelines for third-party users"}
-      href="/files/IBM_Logo_3rdParties_300822.pdf"
+      href="https://www.ibm.com/design/language/files/IBM_Logo_3rdParties_300822.pdf"
       >
 
 ![IBM logo](../../images/resource-cards/acrobat.png)


### PR DESCRIPTION
Closes #1145 (Brand [#11](https://github.com/ibm-brand/design-language/issues/11)

Change to solve 404 error opening the [Third party logo usage](https://www.ibm.com/design/language/ibm-logos/8-bar/#third-party-logo-usage) resource card file on the same tab.

#### Changelog

**Changed**

- [Third party logo usage](https://www.ibm.com/design/language/ibm-logos/8-bar/#third-party-logo-usage) resource card link chaged (from relative path to absolute path).

