### PR TITLE
fix: removes "Design only" tag from Heatmap

### DIFF
--- a/src/pages/data-visualization/charts.mdx
+++ b/src/pages/data-visualization/charts.mdx
@@ -292,7 +292,6 @@ These charts are better suited to highlight the possible correlation between two
 <Column  colMax={3} colXl={4} colLg={4} colMd={4} colSm={2} noGutterSm >
  <OverviewCard
     title="Heatmap"
-    tag="Design only"           
     href="https://www.carbondesignsystem.com/data-visualization/complex-charts#heat-maps"
     >
 


### PR DESCRIPTION
Closes #1167

#### Changelog

**Removed**

- Removed "Design only" tag from Heatmap thumbnail under Correlations section
