### PR TITLE
Update incorrect name for File Storage for VPC

### DIFF
--- a/src/data/app-icons.yaml
+++ b/src/data/app-icons.yaml
@@ -6077,7 +6077,7 @@
     - cube
     - rays
 - name: CloudVPCFileStorage
-  friendly_name: IBM Cloud® Block Storage for VPC
+  friendly_name: IBM Cloud® File Storage for VPC
   category: Stroke style
   aliases:
     - Magenta


### PR DESCRIPTION
The icon for File Storage for VPC is incorrectly labelled currently as "Block" Storage for VPC, this PR will fix the name.

![image](https://user-images.githubusercontent.com/13980028/217028883-1388c18f-a6ec-46c1-bf68-42c345e0f699.png)

(Icon on the right is the file storage icon)


#### Changelog

**New**

- N/A

**Changed**

- Yaml for name of icon

**Removed**

- N/A
