### PR TITLE
update library-health pass

### DIFF
--- a/src/data/app-icons.yaml
+++ b/src/data/app-icons.yaml
@@ -5500,20 +5500,8 @@
     - security
     - Purple
     - Blue
-- name: HealthPassWallet
-  friendly_name: IBM Health Pass Wallet
-  category: Stroke style
-  aliases:
-    - health
-    - pass
-    - wallet
-    - ID
-    - identity
-    - Teal
-    - Purple
-    - Blue
 - name: HealthPassIssuer
-  friendly_name: IBM Health Pass Issuer
+  friendly_name: Unassigned
   category: Stroke style
   aliases:
     - health
@@ -5525,7 +5513,7 @@
     - Purple
     - Blue
 - name: HealthPassVerifier
-  friendly_name: IBM Health Pass Verifier
+  friendly_name: Unassigned
   category: Stroke style
   aliases:
     - health


### PR DESCRIPTION
informed by IBM Legal that the icon used by IBM digital Health pass Wallet was transferred to Merative as a trademark. IBM digital Health Pass Issuer and IBM digital Health Pass Verify were not transferred, so IBM is free to use them elsewhere. They are now marked "unassigned"
