### PR TITLE
fix: fixed the problem with cutting and pasting hex codes

### DIFF
--- a/src/components/SwatchPaletteWidget/_swatch-palette-widget.scss
+++ b/src/components/SwatchPaletteWidget/_swatch-palette-widget.scss
@@ -14,6 +14,7 @@
       }
       .#{$prefix}--swatch-value {
         float: right;
+        user-select: all;
       }
     }
 


### PR DESCRIPTION
Closes #1200 

Fixes the problem with cutting and pasting hex codes

#### Changelog

- Added `user-select: all` on the element containing hex value in the `SwatchPaletteWidget`.