### PR TITLE
feat: update Box link at patterns section

### DIFF
--- a/src/pages/ibm-logos/rebus.mdx
+++ b/src/pages/ibm-logos/rebus.mdx
@@ -339,7 +339,7 @@ rebus, with positive and reversed options.
 <Column colMd={4} colLg={4} noGutterSm>
     <ResourceCard
       subTitle="Eye-Bee-M patterns"
-      href="https://ibm.box.com/s/uf5udm0eo4ifhoj4yco7tkh1c9s37mub"
+      href="https://ibm.box.com/s/yk2rxc455pjluo0v4f1kzwkg99hdu2w0"
       >
 
 ![Box Icon](../../images/resource-cards/box.png)


### PR DESCRIPTION
Closes [358](https://github.com/ibm-brand/center/issues/358) (Brand Center Issue)

Update Box link at patterns section under IBM logos, Rebus page

#### Changelog

**Changed**

- Update Box link on Eye-Bee-M patterns card at patterns section.

