### PR TITLE
fix(gallery): edited video src to absolute links

### DIFF
--- a/src/pages/gallery/index.mdx
+++ b/src/pages/gallery/index.mdx
@@ -52,7 +52,7 @@ Unity, not uniformity. “A corporation should be like a painting; everything vi
 
 <video
   autoPlay loop muted
-  src="/videos/gallery/2306_6_IDL_gallery.mp4"
+  src="https://www.ibm.com/design/language/videos/gallery/2306_6_IDL_gallery.mp4"
 />
 
 ![IBM Knowledge Catalog product demo](./assets/2306_6_IDL_gallery_static.jpg)
@@ -83,7 +83,7 @@ Unity, not uniformity. “A corporation should be like a painting; everything vi
 
 <video
   autoPlay loop muted
-  src="/videos/gallery/2306_10_IDL_gallery.mp4"
+  src="https://www.ibm.com/design/language/videos/gallery/2306_10_IDL_gallery.mp4"
 />
 
 ![animated blue circles resolving to IBM](./assets/2306_10_IDL_gallery_static.jpg)
@@ -272,7 +272,7 @@ Unity, not uniformity. “A corporation should be like a painting; everything vi
 
 <video
   autoPlay loop muted
-  src="/videos/gallery/2306_41_IDL_gallery.mp4"
+  src="https://www.ibm.com/design/language/videos/gallery/2306_41_IDL_gallery.mp4"
 />
 
 ![animation of dimensional details of the IBM 8-bar logo](./assets/2306_41_IDL_gallery_static.jpg)
@@ -303,7 +303,7 @@ Unity, not uniformity. “A corporation should be like a painting; everything vi
 
 <video
   autoPlay loop muted
-  src="/videos/gallery/2306_45_IDL_gallery.mp4"
+  src="https://www.ibm.com/design/language/videos/gallery/2306_45_IDL_gallery.mp4"
 />
 
 ![animation of abstracted AI model tuning sequence](./assets/2306_45_IDL_gallery_static.jpg)
@@ -329,7 +329,7 @@ Unity, not uniformity. “A corporation should be like a painting; everything vi
 
 <video
   autoPlay loop muted
-  src="/videos/gallery/2306_48_IDL_gallery.mp4"
+  src="https://www.ibm.com/design/language/videos/gallery/2306_48_IDL_gallery.mp4"
 />
 
 ![animation of IBM Plex typefaces](./assets/2306_48_IDL_gallery_static.jpg)
@@ -343,7 +343,7 @@ Unity, not uniformity. “A corporation should be like a painting; everything vi
 
 <video
   autoPlay loop muted
-  src="/videos/gallery/2306_49_IDL_gallery.mp4"
+  src="https://www.ibm.com/design/language/videos/gallery/2306_49_IDL_gallery.mp4"
 />
 
 ![animation of IBM Consulting booklet](./assets/2306_49_IDL_gallery_static.jpg)
@@ -385,7 +385,7 @@ Unity, not uniformity. “A corporation should be like a painting; everything vi
 
 <video
   autoPlay loop muted
-  src="/videos/gallery/2306_55_IDL_gallery.mp4"
+  src="https://www.ibm.com/design/language/videos/gallery/2306_55_IDL_gallery.mp4"
 />
 
 ![IBM QRadar product launch animation](./assets/2306_55_IDL_gallery_static.jpg)
@@ -410,7 +410,7 @@ Unity, not uniformity. “A corporation should be like a painting; everything vi
 
 <video
   autoPlay loop muted
-  src="/videos/gallery/2306_58_IDL_gallery.mp4"
+  src="https://www.ibm.com/design/language/videos/gallery/2306_58_IDL_gallery.mp4"
 />
 
 ![animation of lenticular pattern wall](./assets/2306_58_IDL_gallery_static.jpg)
@@ -436,7 +436,7 @@ Unity, not uniformity. “A corporation should be like a painting; everything vi
 
 <video
   autoPlay loop muted
-  src="/videos/gallery/2306_61_IDL_gallery.mp4"
+  src="https://www.ibm.com/design/language/videos/gallery/2306_61_IDL_gallery.mp4"
 />
 
 ![animation of Carbon calendar component](./assets/2306_61_IDL_gallery_static.jpg)
@@ -521,7 +521,7 @@ Unity, not uniformity. “A corporation should be like a painting; everything vi
 
 <video
   autoPlay loop muted
-  src="/videos/gallery/2306_75_IDL_gallery.mp4"
+  src="https://www.ibm.com/design/language/videos/gallery/2306_75_IDL_gallery.mp4"
 />
 
 ![flat-style illustration of a set of eyes](./assets/2306_75_IDL_gallery_static.jpg)
@@ -535,7 +535,7 @@ Unity, not uniformity. “A corporation should be like a painting; everything vi
 
 <video
   autoPlay loop muted
-  src="/videos/gallery/2306_76_IDL_gallery.mp4"
+  src="https://www.ibm.com/design/language/videos/gallery/2306_76_IDL_gallery.mp4"
 />
 
 ![animation](./assets/2306_76_IDL_gallery_static.jpg)
@@ -609,7 +609,7 @@ Unity, not uniformity. “A corporation should be like a painting; everything vi
 
 <video
   autoPlay loop muted
-  src="/videos/gallery/2306_87_IDL_gallery.mp4"
+  src="https://www.ibm.com/design/language/videos/gallery/2306_87_IDL_gallery.mp4"
 />
 
 ![high-resolution media display for IBM Security featuring aurora and pattern](./assets/2306_87_IDL_gallery_static.jpg)
@@ -640,7 +640,7 @@ Unity, not uniformity. “A corporation should be like a painting; everything vi
 
 <video
   autoPlay loop muted
-  src="/videos/gallery/2306_91_IDL_gallery.mp4"
+  src="https://www.ibm.com/design/language/videos/gallery/2306_91_IDL_gallery.mp4"
 />
 
 ![materiality options in wayfinding signage](./assets/2306_91_IDL_gallery_static.jpg)
@@ -692,7 +692,7 @@ Unity, not uniformity. “A corporation should be like a painting; everything vi
 
 <video
   autoPlay loop muted
-  src="/videos/gallery/2306_100_IDL_gallery.mp4"
+  src="https://www.ibm.com/design/language/videos/gallery/2306_100_IDL_gallery.mp4"
 />
 
 ![animation of data fabric concept](./assets/2306_100_IDL_gallery_static.jpg)


### PR DESCRIPTION
…, since relative links resolved wrongly

Closes Brand [issue 359](https://github.com/ibm-brand/center/issues/359) 

New gallery assets got their `src` URLs badly resolved when used relative paths on code.

#### Changelog

**New**

- N/A

**Changed**

- Fixed `src` URLs for gallery videos using their absolute path.
