### PR TITLE
fix(pictograms): hide watsonx pictograms from IDL website

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -25,7 +25,10 @@ exports.onPreBootstrap = async ({ reporter }) => {
     .filter((pictogram) => {
       if (
         pictogram.name === 'ibm--z' ||
-        pictogram.name === 'ibm--z--partition'
+        pictogram.name === 'ibm--z--partition' ||
+        pictogram.name === 'watsonx--ai' ||
+        pictogram.name === 'watsonx--data' ||
+        pictogram.name === 'watsonx--governance' ||
       ) {
         return false;
       }

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -28,7 +28,7 @@ exports.onPreBootstrap = async ({ reporter }) => {
         pictogram.name === 'ibm--z--partition' ||
         pictogram.name === 'watsonx--ai' ||
         pictogram.name === 'watsonx--data' ||
-        pictogram.name === 'watsonx--governance' ||
+        pictogram.name === 'watsonx--governance'
       ) {
         return false;
       }


### PR DESCRIPTION
[Internal issue here](https://github.ibm.com/brand/Pictograms/issues/192)

> These three may or may not be replaced by new artwork, which is why we don't want to fully deprecate them just yet.

https://ibm-studios.slack.com/archives/C06110G3J9E/p1696868173709569

#### To Review

- Verify `watsonx--ai.svg`, `watsonx--data.svg`, and `watsonx--governance.svg` do not show on the pictogram index/library
