### PR TITLE
fix: bug fix for link in resource card on Data viz page

### DIFF
--- a/src/pages/data-visualization/design/basics.mdx
+++ b/src/pages/data-visualization/design/basics.mdx
@@ -155,7 +155,7 @@ actionIcon="launch"
 <Column colMd={4} colLg={4} noGutterSm>
     <ResourceCard
       subTitle="IBM color palette (.ase and .clr)"
-      href="https://github.com/carbon-design-system/carbon/raw/master/packages/colors/artifacts/IBM_Colors.zip"
+      href="https://github.com/carbon-design-system/carbon/raw/main/packages/colors/artifacts/IBM_Colors.zip"
       actionIcon="download"
       >
 


### PR DESCRIPTION
- Fixed a link error to the IBM color palette file on the Data visualization > Design page

