### PR TITLE
fix: bug fix for link in resource card on Resources page

### DIFF
--- a/src/pages/resources.mdx
+++ b/src/pages/resources.mdx
@@ -153,7 +153,7 @@ the alternatives shown here.
     <ResourceCard
       subTitle="IBM color palette (.ase and .clr)"
       actionIcon="download"
-      href="https://github.com/carbon-design-system/carbon/raw/master/packages/colors/artifacts/IBM_Colors.zip"
+      href="https://github.com/carbon-design-system/carbon/raw/main/packages/colors/artifacts/IBM_Colors.zip"
       >
 
 ![Zip Icon](../images/resource-cards/zip.png)


### PR DESCRIPTION
- Fixed a link error to the IBM color palette file on the Resources page > Color section

