### PR TITLE
feat(illustration-designs): removed resources section

### DIFF
--- a/src/pages/illustration/flat-style/design.mdx
+++ b/src/pages/illustration/flat-style/design.mdx
@@ -24,27 +24,6 @@ the following guidelines when crafting flat style illustrations.
   <AnchorLink>Color</AnchorLink>
 </AnchorLinks>
 
-
-## Resources
-
-We’ve built an Adobe Illustrator starter kit you can use to accelerate your proficiency in building compelling, on-brand illustrations. In it you’ll find correctly drawn grids for flat style illustrations, guidance on the underlying anatomy of the style and a fundamental set of simple elements you can use or recombine to form your own new illustration narrative. The kit includes an inspiration gallery of examples showing techniques you can use in this style. These examples aren’t a library of ready-made art; they’re solely provided to help inform your explorations. Use them to study and deconstruct the technical aspects of this delightfully bold style.
-
-<Row className="resource-card-group">
-<Column colMd={4} colLg={4} noGutterSm>
-    <ResourceCard
-      subTitle="Flat style kit (.ai)"
-      aspectRatio="2:1"
-      href="https://github.com/carbon-design-system/design-language-website/raw/master/src/pages/illustration/Illustration-flat-style-kit_v1.ai"
-      actionIcon="download"
-      >
-
-![illustrator Icon](../../../images/resource-cards/illustrator.png)
-
-  </ResourceCard>
-</Column>
-</Row>
-
-
 ## Examples
 
 ![Flat style illustration example 1](./images/flat-1.png)

--- a/src/pages/illustration/isometric-style/design.mdx
+++ b/src/pages/illustration/isometric-style/design.mdx
@@ -24,26 +24,6 @@ isometric style illustrations.
   <AnchorLink>Light and shadow</AnchorLink>
 </AnchorLinks>
 
-## Resources
-
-We’ve built an Adobe Illustrator starter kit you can use to accelerate your proficiency in building compelling, on-brand illustrations. In it you’ll find correctly drawn grids for isometric illustrations, guidance on the underlying anatomy of the isometric style and a fundamental set of simple elements you can use or recombine to form your own new illustration narrative. The kit includes an inspiration gallery of examples showing techniques you can use in this style. These examples aren’t a library of ready-made art; they’re solely provided to help inform your explorations. Use them to study and deconstruct the technical aspects of this spatial style.
-
-<Row className="resource-card-group">
-<Column colMd={4} colLg={4} noGutterSm>
-    <ResourceCard
-      subTitle="Isometric style kit (.ai)"
-      aspectRatio="2:1"
-      href="https://github.com/carbon-design-system/design-language-website/raw/master/src/pages/illustration/Illustration-isometric-style-kit_v1.ai"
-      actionIcon="download"
-      >
-
-![illustrator Icon](../../../images/resource-cards/illustrator.png)
-
-  </ResourceCard>
-</Column>
-</Row>
-
-
 ## Examples
 
 ![Isometric illustration example 1](./images/Gallery1.png)

--- a/src/pages/illustration/line-style/design.mdx
+++ b/src/pages/illustration/line-style/design.mdx
@@ -23,26 +23,6 @@ style illustrations.
   <AnchorLink>Color</AnchorLink>
 </AnchorLinks>
 
-## Resources
-
-We’ve built an Adobe Illustrator starter kit you can use to accelerate your proficiency in building compelling, on-brand illustrations. In it you’ll find foundational grids for line style illustrations, guidance on the underlying anatomy of the style and a fundamental set of simple elements you can use or recombine to form your own new illustration narrative. The kit includes an inspiration gallery of examples showing techniques you can use in this style. These examples aren’t a library of ready-made art; they’re solely provided to help inform your explorations. Use them to study and deconstruct the technical aspects of this versatile style.
-
-<Row className="resource-card-group">
-<Column colMd={4} colLg={4} noGutterSm>
-    <ResourceCard
-      subTitle="Line style kit (.ai)"
-      aspectRatio="2:1"
-      href="https://github.com/carbon-design-system/design-language-website/raw/master/src/pages/illustration/Illustration-line-style-kit_v1.ai"
-      actionIcon="download"
-      >
-
-![illustrator Icon](../../../images/resource-cards/illustrator.png)
-
-  </ResourceCard>
-</Column>
-</Row>
-
-
 ## Examples
 
 ![Line style illustration example 1](./images/line-1.png)


### PR DESCRIPTION
Closes [Brand's issue 473](https://github.com/ibm-brand/center/issues/473)

Removed resources top section of the illustration pages

#### Changelog

**New**

- N/A

**Changed**

- N/A

**Removed**

- Resources section for Illustration/Line-style ; Illustration/Flat-style ; Illustration/Isometric-style
