### PR TITLE
fix(2xgrid): removed card where page linked is down

### DIFF
--- a/src/pages/2x-grid.mdx
+++ b/src/pages/2x-grid.mdx
@@ -441,17 +441,11 @@ baseline grid to guide your content.
 </Column>
 <Column colMd={4} colLg={4} noGutterSm>
     <ResourceCard
-      subTitle="Thinking with type: baseline grid"
-      aspectRatio="2:1"
-      href="http://thinkingwithtype.com/grid/#baseline-grid"
-      ></ResourceCard>
-</Column>
-<Column colMd={4} colLg={4} noGutterSm>
-    <ResourceCard
       subTitle="Grid systems in graphic design"
       aspectRatio="2:1"
       href="https://www.amazon.com/Grid-Systems-Graphic-Design-Communication/dp/3721201450"
-      ></ResourceCard>
+      >
+    </ResourceCard>
 </Column>
 </Row>
 

--- a/src/pages/resources.mdx
+++ b/src/pages/resources.mdx
@@ -249,15 +249,6 @@ href="https://www.ibm.com/design/language/files/2x_video_grid.ai"
 
 <Column colMd={4} colLg={4} noGutterSm>
     <ResourceCard
-      subTitle="Thinking with type: baseline grid"
-      aspectRatio="2:1"
-      href="http://thinkingwithtype.com/grid/#baseline-grid"
-      >
-
-  </ResourceCard>
-</Column>
-<Column colMd={4} colLg={4} noGutterSm>
-    <ResourceCard
       subTitle="Grid systems in graphic design"
       aspectRatio="2:1"
       href="https://www.amazon.com/Grid-Systems-Graphic-Design-Communication/dp/3721201450"


### PR DESCRIPTION
Closes: N/A (Issue pointed out on internal Slack channel)

Removed a resource card for Thinking with type on the 2x grid page.
Page seems to be down for good and no substitute was pointed.

#### Changelog

**New**

- N/A

**Changed**

- N/A

**Removed**

- "Thinking with type: baseline grid" resource card removed due to broken link.
