### PR TITLE
Fix(typeface): changed the link for plex math resource card

### DIFF
--- a/src/pages/typography/typeface.mdx
+++ b/src/pages/typography/typeface.mdx
@@ -212,7 +212,7 @@ American Mathematical Society, Version 2.0, 1999/11/15</Caption>
     <ResourceCard
       subTitle="IBM Plex Math"
       aspectRatio="2:1"
-      href="https://fonts.google.com/?query=ibm+plex"
+      href="https://github.com/IBM/plex/releases/tag/%40ibm%2Fplex-math%401.0.0"
       >
 
 ![github logo](../../images/resource-cards/github.png)


### PR DESCRIPTION
Closes Urgent issue for Brand 

Fix link on resource card for Plex Math on the typeface page

#### Changelog

**New**

- N/A

**Changed**

- fixed link for Plex Math section in a resource card

**Removed**

- N/A