### PR TITLE
Broken links + Rebus card and Slack link updates

### DIFF
--- a/src/gatsby-theme-carbon/components/Footer/index.js
+++ b/src/gatsby-theme-carbon/components/Footer/index.js
@@ -156,7 +156,7 @@ const Content = ({ buildTime }) => (
     <p>
       Have questions?<br />
       Slack us{' '}
-      <a href="https://ibm-studios.slack.com/archives/CK6LZR3PZ">
+      <a target="_blank" href="https://ibm.enterprise.slack.com/archives/ibm-brand" rel="noreferrer">
         #ibm-brand
       </a>{' '}
       (internal IBM users only) or{' '}

--- a/src/pages/color.mdx
+++ b/src/pages/color.mdx
@@ -33,13 +33,12 @@ with nature, yet chosen for their luminous quality in the digital world.
 <Column colMd={4} colLg={4} noGutterSm>
     <ResourceCard
       subTitle="IBM Design Language library"
-      aspectRatio="2:1"
-      href="sketch://add-library/cloud/4f1cbe6c-6626-405e-8c46-a9ae41a30cba"
+      href="https://www.figma.com/files/902667414815738345/project/35070940/%E2%9C%85-IBM-Design-Language?fuid=834811722516621897"
       >
 
-![sketch icon](../images/resource-cards/sketch.png)
+![Figma Icon](../images/resource-cards/figma.png)
 
-  </ResourceCard>
+</ResourceCard>
 </Column>
 <Column colMd={4} colLg={4} noGutterSm>
     <ResourceCard

--- a/src/pages/iconography/pictograms/contribute.mdx
+++ b/src/pages/iconography/pictograms/contribute.mdx
@@ -21,7 +21,7 @@ As IBM continues to innovate with products and services, you may find the need f
 
 Don’t see the pictogram you need in the library? Make your own! Follow these guidelines to ensure visual consistency and proper formatting.
 
-- All pictograms should be unique and not redundant with any existing pictograms in the system. Look through the pictograms in the [IBM Design Sketch kit](sketch://add-library/cloud/4f1cbe6c-6626-405e-8c46-a9ae41a30cba) to ensure that your proposed new pictogram is not already represented.
+- All pictograms should be unique and not redundant with any existing pictograms in the system. Look through the pictograms in the [IBM Design Figma kit](https://www.figma.com/files/902667414815738345/project/35070940/%E2%9C%85-IBM-Design-Language?fuid=834811722516621897) to ensure that your proposed new pictogram is not already represented.
 - All pictograms should adhere to the [IBM Design Language visual style](/iconography/pictograms/design).
 - All pictograms should comply with IBM [accessibility standards](https://www.carbondesignsystem.com/guidelines/accessibility/overview).
 - All pictograms should be usable across all supported platforms and devices.

--- a/src/pages/iconography/pictograms/design.mdx
+++ b/src/pages/iconography/pictograms/design.mdx
@@ -33,14 +33,15 @@ typeface and work well in presentations and marketing communications.
 
 <Row className="resource-card-group">
 <Column colMd={4} colLg={4} noGutterSm>
-    <ResourceCard
-      subTitle="IBM Design Language library"
-      href="sketch://add-library/cloud/4f1cbe6c-6626-405e-8c46-a9ae41a30cba"
-      >
+<ResourceCard
+  subTitle="IBM pictograms library"
+  actionIcon="launch"
+  href="https://www.figma.com/file/PkUl9UBuvA41GPpyl84NBc/Pictograms---IBM-Design-Language?type=design&node-id=0%3A1&mode=design&t=jHxQ3UrLcW3LJNH5-1"
+>
 
-![Sketch icon](../../../images/resource-cards/sketch.png)
+![Figma Icon](../../../images/resource-cards/figma.png)
 
-  </ResourceCard>
+</ResourceCard>
 </Column>
 <Column colMd={4} colLg={4} noGutterSm>
     <ResourceCard

--- a/src/pages/iconography/ui-icons/design.mdx
+++ b/src/pages/iconography/ui-icons/design.mdx
@@ -31,26 +31,15 @@ typeface, they work well at small sizes.
 
 <Row className="resource-card-group">
 <Column colMd={4} colLg={4} noGutterSm>
-    <ResourceCard
-      subTitle="IBM icons (16px, 20px) library"
-      aspectRatio="2:1"
-      href="sketch://add-library/cloud/028e0598-591e-428c-a490-f6ec64b15ea7"
-      >
+<ResourceCard
+  subTitle="IBM icons library"
+  href="https://www.figma.com/file/J5c0d85dSJn9JnBhSYYLmD/Icons---IBM-Design-Language?type=design&node-id=129%3A2&mode=design&t=IgykKAObMrV05Sic-1"
+  actionIcon="launch"
+>
 
-![sketch icon](../../../images/resource-cards/sketch.png)
+![Figma Icon](../../../images/resource-cards/figma.png)
 
-  </ResourceCard>
-</Column>
-<Column colMd={4} colLg={4} noGutterSm>
-    <ResourceCard
-      subTitle="IBM icons (24px, 32px) library"
-      aspectRatio="2:1"
-      href="sketch://add-library/cloud/d530998a-c94c-4f1c-bc0e-c05417e067e3"
-      >
-
-![sketch icon](../../../images/resource-cards/sketch.png)
-
-  </ResourceCard>
+</ResourceCard>
 </Column>
 <Column colMd={4} colLg={4} noGutterSm>
     <ResourceCard

--- a/src/pages/resources.mdx
+++ b/src/pages/resources.mdx
@@ -11,10 +11,7 @@ import AddIcon from '@carbon/icons/es/add/16';
 
 <PageDescription>
 
-Find design tools and repositories for the IBM Plex® typeface and other elements
-used to express the IBM brand. Learn how to request the permission required to
-use the IBM 8-bar logo in IBM materials. View tutorials and discover the
-importance of designing for accessibility.
+Find design tools and repositories for the IBM Plex® typeface and other elements used to express the IBM brand. Learn how to request the permission required to use the IBM 8-bar logo in IBM materials. View tutorials and discover the importance of designing for accessibility.
 
 </PageDescription>
 
@@ -106,43 +103,6 @@ href="https://www.carbondesignsystem.com/designing/kits/sketch"
 ![Google Fonts Icon](../images/resource-cards/google-fonts.png)
 
 </ResourceCard>
-</Column>
-</Row>
-
-<Title>Type alternatives</Title>
-
-<Row className="resource-card-group typography-external">
-<Column colMd={4} colLg={4} noGutterSm>
-    <ResourceCard
-      subTitle={<>Simplified Chinese<br />Noto Sans CJK SC</>}
-      aspectRatio="2:1"
-      href="https://www.google.com/get/noto/#serif-hans"
-      >
-
-![Google Icon](../images/resource-cards/google.png)
-
-</ResourceCard>
-</Column>
-
-<Column colMd={4} colLg={4} noGutterSm>
-    <ResourceCard
-      subTitle={<>Traditional Chinese<br /> Noto Sans CJK TC</>}
-      aspectRatio="2:1"
-      href="https://www.google.com/get/noto/#sans-hant"
-      >
-
-![Google Icon](../images/resource-cards/google.png)
-
-</ResourceCard>
-</Column>
-
-<Column colMd={2} colLg={3} offsetMd={1} offsetLg={1} className="hide-mobile type-alt-sidebar" >
-<Aside>
-
-The Chinese scripts are currently under development. In the meantime, please use
-the alternatives shown here.
-
-</Aside>
 </Column>
 </Row>
 
@@ -284,8 +244,8 @@ href="https://www.ibm.com/design/language/files/2x_video_grid.ai"
 
 <Column colMd={4} colLg={4} noGutterSm>
 <ResourceCard
-subTitle="Eye-Bee-M patterns"
-href="https://ibm.box.com/s/uf5udm0eo4ifhoj4yco7tkh1c9s37mub"
+subTitle="Rebus patterns"
+href="https://ibm.box.com/s/vth9qr6j9hvobxvizje5wa0vopv49jwp"
 >
 
 ![box icon](../images/resource-cards/box.png)

--- a/src/pages/resources.mdx
+++ b/src/pages/resources.mdx
@@ -35,21 +35,21 @@ Find design tools and repositories for the IBM Plex® typeface and other element
 <Column colMd={4} colLg={4} noGutterSm>
     <ResourceCard
       subTitle="IBM Design Language library"
-      href="sketch://add-library/cloud/4f1cbe6c-6626-405e-8c46-a9ae41a30cba"
+      href="https://www.figma.com/files/902667414815738345/project/35070940/%E2%9C%85-IBM-Design-Language?fuid=834811722516621897"
       >
 
-![Sketch Icon](../images/resource-cards/sketch.png)
+![Figma Icon](../images/resource-cards/figma.png)
 
 </ResourceCard>
 </Column>
 
 <Column colMd={4} colLg={4} noGutterSm>
 <ResourceCard
-subTitle="Carbon libraries"
-href="https://www.carbondesignsystem.com/designing/kits/sketch"
+subTitle="Carbon all themes library"
+href="https://www.figma.com/file/YAnB1jKx0yCUL29j6uSLpg/(v11)-All-themes---Carbon-Design-System?type=design&node-id=58%3A2763&mode=design&t=eLDxgVJyvZR01HtA-1"
 >
 
-![Carbon theme libraries](../images/resource-cards/sketch.png)
+![Figma Icon](../images/resource-cards/figma.png)
 
 </ResourceCard>
 </Column>
@@ -261,23 +261,12 @@ href="https://ibm.box.com/s/vth9qr6j9hvobxvizje5wa0vopv49jwp"
 <Row className="resource-card-group">
 <Column colMd={4} colLg={4} noGutterSm>
 <ResourceCard
-subTitle="IBM icons (16px, 20px) library"
-href="sketch://add-library/028e0598-591e-428c-a490-f6ec64b15ea7"
-actionIcon="download"
+subTitle="IBM icons library"
+href="https://www.figma.com/file/J5c0d85dSJn9JnBhSYYLmD/Icons---IBM-Design-Language?type=design&node-id=129%3A2&mode=design&t=IgykKAObMrV05Sic-1"
+actionIcon="launch"
 >
 
-![Sketch Icon](../images/resource-cards/sketch.png)
-
-</ResourceCard>
-</Column>
-<Column colMd={4} colLg={4} noGutterSm>
-    <ResourceCard
-      subTitle="IBM icons (24px, 32px) library"
-      actionIcon="download"
-      href="sketch://add-library/d530998a-c94c-4f1c-bc0e-c05417e067e3"
-      >
-
-![Sketch Icon](../images/resource-cards/sketch.png)
+![Figma Icon](../images/resource-cards/figma.png)
 
 </ResourceCard>
 </Column>
@@ -418,12 +407,12 @@ href="https://developer.apple.com/design/human-interface-guidelines/macos/icons-
 <Row className="resource-card-group">
 <Column colMd={4} colLg={4} noGutterSm>
     <ResourceCard
-      subTitle="IBM productive pictograms master"
-      actionIcon="download"
-      href="https://github.com/carbon-design-system/carbon/raw/main/packages/pictograms/master/productive-pictogram-master.ai"
+      subTitle="IBM pictograms library"
+      actionIcon="launch"
+      href="https://www.figma.com/file/PkUl9UBuvA41GPpyl84NBc/Pictograms---IBM-Design-Language?type=design&node-id=0%3A1&mode=design&t=jHxQ3UrLcW3LJNH5-1"
       >
 
-![Adobe Illustrator](../images/resource-cards/illustrator.png)
+![Figma Icon](../images/resource-cards/figma.png)
 
 </ResourceCard>
 </Column>
@@ -611,7 +600,7 @@ href="https://developer.apple.com/design/human-interface-guidelines/macos/icons-
     <ResourceCard
       subTitle="Carbon design kits"
       aspectRatio="2:1"
-      href="https://carbondesignsystem.com/designing/kits/sketch/"
+      href="https://carbondesignsystem.com/designing/kits/figma"
       >
 
 ![carbon Icon](../images/resource-cards/carbon.png)

--- a/src/pages/resources.mdx
+++ b/src/pages/resources.mdx
@@ -394,7 +394,7 @@ href="https://developer.apple.com/design/human-interface-guidelines/macos/icons-
 <Column colMd={4} colLg={4} noGutterSm>
     <ResourceCard
       subTitle="Windows UWP app icons"
-      href="https://docs.microsoft.com/en-us/windows/uwp/design/style/app-icons-and-logos"
+      href="https://learn.microsoft.com/en-us/windows/apps/design/style/iconography/app-icon-design"
       >
 
 ![Microsoft Icon](../images/resource-cards/microsoft.png)

--- a/src/pages/resources.mdx
+++ b/src/pages/resources.mdx
@@ -352,11 +352,11 @@ actionIcon="launch"
 
 <Column colMd={4} colLg={4} noGutterSm>
 <ResourceCard
-      subTitle="Public app store graphics (.png)"
-      href="https://ibm.box.com/s/deryxio58jbgu4jut8twnxt7l07acep1"
+      subTitle={<>Public app store graphics<br />(IBM ID required)</>}
+      href=" https://github.ibm.com/brand/App-icons/tree/master/GooglePlay_FeatureGraphics"
       >
 
-![Box Icon](../images/resource-cards/box.png)
+![Github Icon](../images/resource-cards/github.png)
 
 </ResourceCard>
 </Column>

--- a/src/pages/resources.mdx
+++ b/src/pages/resources.mdx
@@ -352,7 +352,7 @@ actionIcon="launch"
 
 <Column colMd={4} colLg={4} noGutterSm>
 <ResourceCard
-      subTitle={<>Public app store graphics<br />(IBM ID required)</>}
+      subTitle={<>App store graphics<br />(IBM ID required)</>}
       href=" https://github.ibm.com/brand/App-icons/tree/master/GooglePlay_FeatureGraphics"
       >
 


### PR DESCRIPTION
Closes [Brand issue #620](https://github.com/ibm-brand/center/issues/620)

Link fixes on footer and on Resources page + subsection removal

#### Changelog

**New**

- N/A

**Changed**

- Changed title from Eye-Bee-M to Rebus in a card on the IBM Logos section from Resources page as well as it's box link
- Fixed the ibm-brand channel link in the IDL footer
- Plenty of links on resources cards pointing to Sketch materials were updated to Figma links
- Other broken links were fixed

**Removed**

- Type alternatives subsection on the Typography section from the Resources page, since IBM Plex Traditional Chinese is already available
