### PR TITLE
chore: reinstate IBM Z pictogram

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -24,7 +24,6 @@ exports.onPreBootstrap = async ({ reporter }) => {
     .map(removeUnusedData)
     .filter((pictogram) => {
       if (
-        pictogram.name === 'ibm--z' ||
         pictogram.name === 'ibm--z--partition' ||
         pictogram.name === 'tokyo--volcano'
       ) {

--- a/src/components/SVGLibraries/PictogramLibrary/PictogramCategory.js
+++ b/src/components/SVGLibraries/PictogramLibrary/PictogramCategory.js
@@ -23,7 +23,6 @@ const IconCategory = ({ category, pictograms, columnCount }) => {
         {pictograms
           .filter((pictogram) => {
             if (
-              pictogram.name === 'ibm--z' ||
               pictogram.name === 'ibm--z--partition' ||
               pictogram.name === 'ibm--z-and-linuxone-multi-frame' ||
               pictogram.name === 'ibm--z-and-linuxone-single-frame' ||


### PR DESCRIPTION
Closes [issue 1402](https://github.com/carbon-design-system/design-language-website/issues/1402)

Reinstate the `ibm--z` pictogram in `design-language-website`

#### Changelog

**New**

- N/A

**Changed**

- Update areas that were hiding the `ibm--z` pictogram

**Removed**

- N/A

