### PR TITLE
ci(deploy.yml): bumped max old space size to close to 7GB limit

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Build site
         env:
-          NODE_OPTIONS: "--max_old_space_size=4096"
+          NODE_OPTIONS: "--max_old_space_size=7000"
         run: yarn build:prefix
 
       - uses: jakejarvis/s3-sync-action@master


### PR DESCRIPTION
Closes #1417 

Bumped old max size on Node options for S3 deployment

#### Changelog

**Changed**

- Changed `--max_old_space_size` from 4GB to 7GB on `deploy.yml`


