### PR TITLE
feat(plex.scss): added styles and for plex font fallback

### DIFF
--- a/src/styles/_plex.scss
+++ b/src/styles/_plex.scss
@@ -1,0 +1,210 @@
+// LATIN="U+0020-00FF"
+// LATINEXT="U+0100-1EF9"
+// PUNCTUATION="U+2000-FB02"
+
+//Latin
+/* Subset: Latin1 */
+@font-face {
+  font-family: 'IBM Plex Sans Var';
+  font-style: normal;
+  font-weight: 100 900;
+  src: url('https://1.www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans-Variable/fonts/split/woff2/IBM Plex Sans Var-Roman-Latin1.woff2')
+      format('woff2-variations'),
+    url('https://1.www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans-Variable/fonts/split/woff2/IBM Plex Sans Var-Roman-Latin1.woff2')
+      format('woff2');
+  unicode-range: U+0020-007E, U+00A0-00FF, U+0131, U+0152-0153, U+02C6, U+02DA,
+    U+02DC, U+2013-2014, U+2018-201A, U+201C-201E, U+2020-2022, U+2026, U+2030,
+    U+2039-203A, U+2044, U+20AC, U+2122, U+2212, U+FB01-FB02;
+}
+/* Subset: Latin2 */
+@font-face {
+  font-family: 'IBM Plex Sans Var';
+  font-style: normal;
+  font-weight: 100 900;
+  src: url('https://1.www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans-Variable/fonts/split/woff2/IBM Plex Sans Var-Roman-Latin2.woff2')
+      format('woff2-variations'),
+    url('https://1.www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans-Variable/fonts/split/woff2/IBM Plex Sans Var-Roman-Latin2.woff2')
+      format('woff2');
+  unicode-range: U+0100-0101, U+0104-0130, U+0132-0151, U+0154-017F, U+018F,
+    U+0192, U+01A0-01A1, U+01AF-01B0, U+01FA-01FF, U+0218-021B, U+0237, U+0259,
+    U+1E80-1E85, U+1E9E, U+20A1, U+20A4, U+20A6, U+20A8-20AA, U+20AD-20AE,
+    U+20B1-20B2, U+20B4-20B5, U+20B8-20BA, U+20BD, U+20BF;
+}
+/* Subset: Latin3 */
+@font-face {
+  font-family: 'IBM Plex Sans Var';
+  font-style: normal;
+  font-weight: 100 900;
+  src: url('https://1.www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans-Variable/fonts/split/woff2/IBM Plex Sans Var-Roman-Latin3.woff2')
+      format('woff2-variations'),
+    url('https://1.www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans-Variable/fonts/split/woff2/IBM Plex Sans Var-Roman-Latin3.woff2')
+      format('woff2');
+  unicode-range: U+0102-0103, U+01CD-01DC, U+1EA0-1EF9, U+20AB;
+}
+/* Subset: Pi */
+@font-face {
+  font-family: 'IBM Plex Sans Var';
+  font-style: normal;
+  font-weight: 100 900;
+  src: url('https://1.www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans-Variable/fonts/split/woff2/IBM Plex Sans Var-Roman-Pi.woff2')
+      format('woff2-variations'),
+    url('https://1.www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans-Variable/fonts/split/woff2/IBM Plex Sans Var-Roman-Pi.woff2')
+      format('woff2');
+  unicode-range: U+03C0, U+0E3F, U+2000-200D, U+2010-2012, U+2015, U+2028-2029,
+    U+202F, U+2032-2033, U+2070, U+2074-2079, U+2080-2089, U+2113, U+2116,
+    U+2126, U+212E, U+2150-2151, U+2153-215E, U+2190-2199, U+21A9-21AA,
+    U+21B0-21B3, U+21B6-21B7, U+21BA-21BB, U+21C4, U+21C6, U+2202, U+2206,
+    U+220F, U+2211, U+2215, U+2219-221A, U+221E, U+222B, U+2236, U+2248, U+2260,
+    U+2264-2265, U+25CA, U+2713, U+274C, U+2B0E-2B11, U+ECE0, U+EFCC, U+FEFF,
+    U+FFFD;
+}
+
+//Latin italic
+/* Subset: Latin1 */
+@font-face {
+  font-family: 'IBM Plex Sans Var';
+  font-style: italic;
+  font-weight: 100 900;
+  src: url('https://1.www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans-Variable/fonts/split/woff2/IBM Plex Sans Var-Italic-Latin1.woff2')
+      format('woff2-variations'),
+    url('https://1.www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans-Variable/fonts/split/woff2/IBM Plex Sans Var-Italic-Latin1.woff2')
+      format('woff2');
+  unicode-range: U+0020-007E, U+00A0-00FF, U+0131, U+0152-0153, U+02C6, U+02DA,
+    U+02DC, U+2013-2014, U+2018-201A, U+201C-201E, U+2020-2022, U+2026, U+2030,
+    U+2039-203A, U+2044, U+20AC, U+2122, U+2212, U+FB01-FB02;
+}
+/* Subset: Latin2 */
+@font-face {
+  font-family: 'IBM Plex Sans Var';
+  font-style: italic;
+  font-weight: 100 900;
+  src: url('https://1.www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans-Variable/fonts/split/woff2/IBM Plex Sans Var-Italic-Latin2.woff2')
+      format('woff2-variations'),
+    url('https://1.www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans-Variable/fonts/split/woff2/IBM Plex Sans Var-Italic-Latin2.woff2')
+      format('woff2');
+  unicode-range: U+0100-0101, U+0104-0130, U+0132-0151, U+0154-017F, U+018F,
+    U+0192, U+01A0-01A1, U+01AF-01B0, U+01FA-01FF, U+0218-021B, U+0237, U+0259,
+    U+1E80-1E85, U+1E9E, U+20A1, U+20A4, U+20A6, U+20A8-20AA, U+20AD-20AE,
+    U+20B1-20B2, U+20B4-20B5, U+20B8-20BA, U+20BD, U+20BF;
+}
+/* Subset: Latin3 */
+@font-face {
+  font-family: 'IBM Plex Sans Var';
+  font-style: italic;
+  font-weight: 100 900;
+  src: url('https://1.www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans-Variable/fonts/split/woff2/IBM Plex Sans Var-Italic-Latin3.woff2')
+      format('woff2-variations'),
+    url('https://1.www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans-Variable/fonts/split/woff2/IBM Plex Sans Var-Italic-Latin3.woff2')
+      format('woff2');
+  unicode-range: U+0102-0103, U+01CD-01DC, U+1EA0-1EF9, U+20AB;
+}
+/* Subset: Pi */
+@font-face {
+  font-family: 'IBM Plex Sans Var';
+  font-style: italic;
+  font-weight: 100 900;
+  src: url('https://1.www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans-Variable/fonts/split/woff2/IBM Plex Sans Var-Italic-Pi.woff2')
+      format('woff2-variations'),
+    url('https://1.www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Sans-Variable/fonts/split/woff2/IBM Plex Sans Var-Italic-Pi.woff2')
+      format('woff2');
+  unicode-range: U+03C0, U+0E3F, U+2000-200D, U+2010-2012, U+2015, U+2028-2029,
+    U+202F, U+2032-2033, U+2070, U+2074-2079, U+2080-2089, U+2113, U+2116,
+    U+2126, U+212E, U+2150-2151, U+2153-215E, U+2190-2199, U+21A9-21AA,
+    U+21B0-21B3, U+21B6-21B7, U+21BA-21BB, U+21C4, U+21C6, U+2202, U+2206,
+    U+220F, U+2211, U+2215, U+2219-221A, U+221E, U+222B, U+2236, U+2248, U+2260,
+    U+2264-2265, U+25CA, U+2713, U+274C, U+2B0E-2B11, U+ECE0, U+EFCC, U+FEFF,
+    U+FFFD;
+}
+
+// Mono
+@font-face {
+  font-family: 'IBM Plex Mono';
+  font-style: normal;
+  font-weight: 400;
+  src: local('IBM Plex Mono'), local('IBMPlexMono'),
+    url('https://1.www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Mono/fonts/split/woff2/IBMPlexMono-Regular-Latin1.woff2')
+      format('woff2');
+  unicode-range: U+0000, U+000D, U+0020-007E, U+00A0-00A3, U+00A4-00FF, U+0131,
+    U+0152-0153, U+02C6, U+02DA, U+02DC, U+2013-2014, U+2018-201A, U+201C-201E,
+    U+2020-2022, U+2026, U+2030, U+2039-203A, U+2044, U+2074, U+20AC, U+2122,
+    U+2212, U+FB01-FB02;
+}
+
+@font-face {
+  font-family: 'IBM Plex Mono';
+  font-style: normal;
+  font-weight: 400;
+  src: local('IBM Plex Mono'), local('IBMPlexMono'),
+    url('https://1.www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Mono/fonts/split/woff2/IBMPlexMono-Regular-Latin2.woff2')
+      format('woff2');
+  unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+20A0-20AB, U+20AD-20CF,
+    U+2C60-2C7F, U+A720-A7FF, U+FB01-FB02;
+}
+
+@font-face {
+  font-family: 'IBM Plex Mono';
+  font-style: normal;
+  font-weight: 400;
+  src: local('IBM Plex Mono'), local('IBMPlexMono'),
+    url('https://1.www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Mono/fonts/split/woff2/IBMPlexMono-Regular-Latin3.woff2')
+      format('woff2');
+  unicode-range: U+0102-0103, U+1EA0-1EF9, U+20AB;
+}
+
+@font-face {
+  font-family: 'IBM Plex Mono';
+  font-style: normal;
+  font-weight: 400;
+  src: local('IBM Plex Mono'), local('IBMPlexMono'),
+    url('https://1.www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Mono/fonts/split/woff2/IBMPlexMono-Regular-Pi.woff2')
+      format('woff2');
+  unicode-range: U+0E3F, U+2032-2033, U+2070, U+2075-2079, U+2080-2081, U+2083,
+    U+2085-2089, U+2113, U+2116, U+2126, U+212E, U+2150-2151, U+2153-215E,
+    U+2190-2199, U+21A9-21AA, U+21B0-21B3, U+21B6-21B7, U+21BA-21BB, U+21C4,
+    U+21C6, U+2202, U+2206, U+220F, U+2211, U+221A, U+221E, U+222B, U+2248,
+    U+2260, U+2264-2265, U+25CA, U+2713, U+274C, U+2B0E-2B11, U+EBE1-EBE7,
+    U+ECE0, U+EFCC;
+}
+
+@font-face {
+  font-family: 'IBM Plex Mono';
+  font-style: normal;
+  font-weight: 400;
+  src: local('IBM Plex Mono'), local('IBMPlexMono'),
+    url('https://1.www.s81c.com/common/carbon/plex/fonts/IBM-Plex-Mono/fonts/split/woff2/IBMPlexMono-Regular-Cyrillic.woff2')
+      format('woff2');
+  unicode-range: U+0400-045F, U+0472-0473, U+0490-049D, U+04A0-04A5, U+04AA-04AB,
+    U+04AE-04B3, U+04B6-04BB, U+04C0-04C2, U+04CF-04D9, U+04DC-04DF, U+04E2-04E9,
+    U+04EE-04F5, U+04F8-04F9;
+}
+
+// Fallback
+@font-face {
+  font-family: 'IBM Plex Sans';
+  font-display: swap;
+  src: url('https://www.ibm.com/design/language/fonts/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-Regular.woff')
+    format('woff');
+}
+
+@font-face {
+  font-family: 'IBM Plex Sans';
+  font-display: swap;
+  src: url('https://www.ibm.com/design/language/fonts/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-SemiBold.woff');
+  font-weight: 600;
+}
+
+// IE 11 support
+body {
+  font-size: 1em;
+  line-height: 1.5;
+  font-family: 'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif;
+}
+
+@supports (font-variation-settings: normal) {
+  // This rule includes both html and body to outgun the carbon--type-reset mixin
+  // carbon--type-reset is being called inadvertantly when sites invoke the carbon--type-style mixin
+  // Without it both html and body, the font-family gets overridden with `IBM Plex Sans` (not the variable font)
+  html body {
+    font-family: 'IBM Plex Sans Var', 'Helvetica Neue', Arial, sans-serif;
+  }
+}

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -46,3 +46,5 @@
 // Table component
 //---------------------------------------
 @import 'narrative';
+
+@import 'plex';


### PR DESCRIPTION
Closes N/A

Solves entire Design Language site missing plex font

#### Changelog

**New**

- Added `_plex.scss` to create a fallback alternative to where the site was getting the Plex font from.

**Changed**

- `index.scss` to include the import statement to use this new styling file

**Removed**

- N/A
