### PR TITLE
Fixed link for third party logo request cards

### DIFF
--- a/src/pages/ibm-logos/8-bar.mdx
+++ b/src/pages/ibm-logos/8-bar.mdx
@@ -29,10 +29,10 @@ offerings.
 
 <Row className="resource-card-group">
 <Column colMd={4} colLg={4} noGutterSm>
-    <ResourceCard
-                  subTitle={<>Third-party IBM logo request<br />(IBM ID required)</>}
-      href="https://prdpcrhibmbl01.w3-969.ibm.com/marketing/logotool/logotool.nsf/BrandingLogoHome?Openform"
-      >
+  <ResourceCard
+    subTitle={<>Third-party IBM logo request<br />(IBM ID required)</>}
+    href="https://ibm.my.workfront.com/requests/new?activeTab=tab-new-helpRequest&projectID=62b5b[…]1899d2b6322f7ff09b9c&path=675712d60004897c9565fc8d16cb11fe"
+  >
 
 ![ibm icon](../../images/resource-cards/ibm.svg)
 

--- a/src/pages/resources.mdx
+++ b/src/pages/resources.mdx
@@ -223,7 +223,7 @@ href="https://www.ibm.com/design/language/files/2x_video_grid.ai"
 <Column colMd={4} colLg={4} noGutterSm>
 <ResourceCard
   subTitle={<>Third-party IBM logo request<br />(IBM ID required)</>}
-  href="https://prdpcrhibmbl01.w3-969.ibm.com/marketing/logotool/logotool.nsf/BrandingLogoHome?Openform"
+  href="https://ibm.my.workfront.com/requests/new?activeTab=tab-new-helpRequest&projectID=62b5b[…]1899d2b6322f7ff09b9c&path=675712d60004897c9565fc8d16cb11fe"
 >
 
 ![IBM Icon](../images/resource-cards/ibm.svg)


### PR DESCRIPTION
Closes N/A

Urgent request from Brand team to fix broken link for third party logo requests

#### Changelog

**Changed**

- Changed links on resource cards on `8-bar` and `resources` pages for third party logo requests

**Removed**

- N/A
